### PR TITLE
sixtracklib/common: Fix bug in NS(BeamMonitor_are_present_in_buffer)

### DIFF
--- a/sixtracklib/common/be_monitor/output_buffer.h
+++ b/sixtracklib/common/be_monitor/output_buffer.h
@@ -129,7 +129,7 @@ SIXTRL_INLINE bool NS(BeamMonitor_are_present_in_buffer)(
             typedef NS(be_monitor_turn_t) nturn_t;
 
             ptr_monitor_t monitor = ( ptr_monitor_t
-                )( uintptr_t )NS(BeamMonitor_get_out_address)( monitor );
+                )( uintptr_t )NS(Object_get_begin_addr)( obj_it );
 
             if( ( monitor != SIXTRL_NULLPTR ) &&
                 ( NS(BeamMonitor_get_num_stores)( monitor ) > ( nturn_t )0u ) )


### PR DESCRIPTION
- Used NS(BeamMonitor_get_out_addr) instead of NS(Object_get_begin_addr)
-> detected by gcc due to an initialized-used use of the monitor variable