### PR TITLE
Update to pysixtracklib TrackJob implementation

### DIFF
--- a/examples/python/track_job.py
+++ b/examples/python/track_job.py
@@ -1,13 +1,8 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
-import ctypes as ct
 import argparse
 import pysixtracklib as pyst
-from pysixtracklib.stcommon import *
-from cobjects import CBuffer
-
-import pdb
 
 if __name__ == '__main__':
 
@@ -16,38 +11,57 @@ if __name__ == '__main__':
 
     parser = argparse.ArgumentParser()
 
-    parser.add_argument( "architecture", help="Architecture to be used" )
+    parser.add_argument("architecture", help="Architecture to be used")
 
-    parser.add_argument( "-d", "--device", help="Device id string", default="",
-                         dest="device_id_str", required=False, )
+    parser.add_argument("-d", "--device", help="Device id string", default="",
+                        dest="device_id", required=False, )
 
-    parser.add_argument( "-p", "--particles",
-                         help="Path to particles dump file",
-                         dest="particles_buffer", required=True, )
+    parser.add_argument("-p", "--particles",
+                        help="Path to particles dump file",
+                        dest="particles_buffer", required=True, )
 
-    parser.add_argument( "-e", "--beam-elements",
-                         help="Path to beam-elements dump file",
-                         dest="beam_elements_buffer", required=True, )
+    parser.add_argument("-e", "--beam-elements",
+                        help="Path to beam-elements dump file",
+                        dest="beam_elements_buffer", required=True, )
 
-    parser.add_argument( "-E", "--elem_by_elem_out_turns",
-                        help="Number of turns to dump element by element wise",
-                        required=False, default=0, type=int,
-                        dest="elem_by_elem_out_turns" )
+    parser.add_argument(
+        "-E",
+        "--until_turn_elem_by_elem",
+        help="Dump all particles element by element wise until this turn",
+        required=False,
+        default=0,
+        type=int,
+        dest="until_turn_elem_by_elem")
 
-    parser.add_argument( "-T", "--turn_by_turn_out_turns",
-                        help="Number of turn-by-turn outputs",
-                        required=False, default=0, type=int,
-                        dest="turn_by_turn_out_turns" )
+    parser.add_argument(
+        "-T",
+        "--until_turn_turn_by_turn",
+        help="Dump the state of all particles at the end of each turn" +
+        ";Only applies if not alreay performing a diffferent output operation",
+        required=False,
+        default=0,
+        type=int,
+        dest="until_turn_turn_by_turn")
 
-    parser.add_argument( "-t", "--target_num_out_turns",
-                         help="Target number of end-of-turn outputs",
-                         required=False, default=0, type=int,
-                         dest="target_num_out_turns" )
+    parser.add_argument(
+        "-t",
+        "--until_turn_output",
+        help="Dump the state of all particles at the end of each turn " +
+        "every --skip_out_turns turn",
+        required=False,
+        default=0,
+        type=int,
+        dest="until_turn_output")
 
-    parser.add_argument( "-s", "--skip_out_turns",
-                         help="Number of turns between two consequetive outputs " + \
-                              "at the end of each turn", type=int,
-                         required=False, default=1, dest="skip_out_turns" )
+    parser.add_argument(
+        "-s",
+        "--skip_out_turns",
+        help="Number of turns between two consequetive outputs for " +
+        "with --until_turn_output; has no effect on other output modes",
+        type=int,
+        required=False,
+        default=1,
+        dest="skip_out_turns")
 
     args = parser.parse_args()
 
@@ -55,73 +69,80 @@ if __name__ == '__main__':
     # Setup input buffers and track job
 
     path_to_pb = args.particles_buffer
-    pb = CBuffer.fromfile( path_to_pb )
+    particles_set = pyst.ParticlesSet.fromfile(path_to_pb)
 
     path_to_eb = args.beam_elements_buffer
-    beam_elements = pyst.Elements.fromfile( path_to_eb )
+    beam_elements = pyst.Elements.fromfile(path_to_eb)
 
-    if  args.turn_by_turn_out_turns > 0 or args.target_num_out_turns > 0:
-        pyst.insert_end_of_turn_beam_monitors( beam_elements,
-            args.turn_by_turn_out_turns, args.elem_by_elem_out_turns,
-            args.target_num_out_turns, args.skip_out_turns )
+    num_beam_monitors = pyst.append_beam_monitors_to_lattice(
+        beam_elements.cbuffer,
+        args.until_turn_elem_by_elem,
+        args.until_turn_turn_by_turn,
+        args.until_turn_output,
+        args.skip_out_turns)
 
-    pdb.set_trace()
+    print("Added {0} beam monitors to the lattice".format(num_beam_monitors))
 
-    job = pyst.TrackJob( args.architecture, args.device_id_str,
-        pb, beam_elements.cbuffer, None, args.elem_by_elem_out_turns )
+    # =======================================================================
+    # Create the TrackJob instance
+
+    job = pyst.TrackJob(beam_elements.cbuffer, particles_set.cbuffer,
+                        until_turn_elem_by_elem=args.until_turn_elem_by_elem,
+                        arch=args.architecture, device_id=args.device_id)
 
     # ========================================================================
     # Print summary about configuration
 
-    print( "TrackJob:" )
-    print( "----------------------------------------------------------------" )
-    print( "architecture            : {0}".format( job.type_str() ) )
+    print("TrackJob:")
+    print("----------------------------------------------------------------")
+    print("architecture                 : {0}".format(job.type_str()))
 
-    if job.has_elem_by_elem_outupt():
-        print( "has elem_by_elem output : yes" )
+    if job.has_elem_by_elem_output():
+        print("has elem_by_elem output      : yes")
     else:
-        print( "has elem_by_elem output : no" )
-
+        print("has elem_by_elem output      : no")
 
     if job.has_beam_monitor_output():
-        print( "has beam monitor output : yes" )
-        print( "num beam monitors       : {0}".format(
-            job.num_beam_monitors() ) )
+        print("has beam monitor output      : yes")
+        print("num beam monitors            : {0}".format(
+            job.num_beam_monitors()))
     else:
-        print( "has beam monitor output : no" )
+        print("has beam monitor output      : no")
 
-    if  job.has_output_buffer():
-        print( "has output buffer       : yes" )
+    if job.has_output_buffer():
+        print("has output buffer            : yes")
     else:
-        print( "has output buffer       : no" )
+        print("has output buffer            : no")
 
-    print( "num elem by elem turns  : {0:6d}".format( args.elem_by_elem_out_turns ) )
-    print( "num turn-by-turn turns  : {0:6d}".format( args.turn_by_turn_out_turns ) )
-    print( "target num of turns     : {0:6d}".format( args.target_num_out_turns ) )
-    print( "num of turns out skip   : {0:6d}".format( args.skip_out_turns ) )
+    print(
+        "dump elem-by-elem until turn : {0}".format(args.until_turn_elem_by_elem))
+    print(
+        "dump turn-by-turn until turn : {0}".format(args.until_turn_turn_by_turn))
+    print("traget num output turns      : {0}".format(args.until_turn_output))
+    print("dump every number of turns   : {0}".format(args.skip_out_turns))
 
     # ========================================================================
     # Perform tracking
 
     success = True
-    if args.elem_by_elem_out_turns > 0:
-        print( "\r\ntracking {0} turns element by element ... ".format(
-            args.elem_by_elem_out_turns ) )
+    if args.until_turn_elem_by_elem > 0:
+        print("\r\ntracking until turn {0} element by element ... ".format(
+            args.until_turn_elem_by_elem))
 
-        status  = job.track_elem_by_elem_output( args.elem_by_elem_out_turns )
-        success = bool( status == 0 )
+        status = job.track_elem_by_elem(args.until_turn_elem_by_elem)
+        success = bool(status == 0)
 
-        print( "{0}".format( success and "SUCCESS" or "FAILURE" ) )
+        print("{0}".format(success and "SUCCESS" or "FAILURE"))
 
-    if success and args.target_num_out_turns > args.elem_by_elem_out_turns:
-        print( "\r\ntracking {0} turns ... ".format(
-                args.target_num_out_turns ) )
+    if success and args.until_turn_output > args.until_turn_elem_by_elem:
+        print("\r\ntracking until turn {0} ... ".format(
+            args.until_turn_output))
 
-        status = job.track( args.target_num_out_turns )
-        print( status )
-        success = bool( status == 0 )
+        status = job.track(args.until_turn_output)
+        print(status)
+        success = bool(status == 0)
 
-        print( "{0}".format( success and "SUCCESS" or "FAILURE" ) )
+        print("{0}".format(success and "SUCCESS" or "FAILURE"))
 
     # ========================================================================
     # Collect data before accessing particle_buffer and output_buffer
@@ -138,18 +159,17 @@ if __name__ == '__main__':
         output_buffer = job.output_buffer
 
         if job.has_elem_by_elem_output():
-            assert( output_buffer.n_objects > job.elem_by_elem_output_offset() )
+            assert(output_buffer.n_objects > job.elem_by_elem_output_offset())
             # These are the particles containing the elem by elem information
             elem_by_elem_particles = output_buffer.get_object(
-                 job.elem_by_elem_output_offset() )
-
+                job.elem_by_elem_output_offset(), cls=pyst.Particles)
 
         if job.has_beam_monitor_output():
             out_offset = job.beam_monitor_output_offset()
             num_monitors = job.num_beam_monitors()
-            for ii in range( out_offset, num_monitors + out_offset ):
-                assert( ii < output_buffer.n_objects )
-                out_particles = output_buffer.get_object( ii )
+            for ii in range(out_offset, num_monitors + out_offset):
+                assert(ii < output_buffer.n_objects)
+                out_particles = output_buffer.get_object(
+                    ii, cls=pyst.Particles)
 
     # finished
-

--- a/examples/python/track_job_simple.py
+++ b/examples/python/track_job_simple.py
@@ -1,0 +1,28 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+import pysixtracklib as pyst
+
+elements=pyst.Elements()
+elements.Drift(length=1.2)
+elements.Multipole(knl=[0,0.001])
+
+partset=pyst.ParticlesSet()
+particles=partset.Particles(num_particles=100)
+
+particles.px+=range(len(particles.px))
+particles.px*=1e-2
+
+job = pyst.TrackJob(elements.cbuffer,partset.cbuffer)
+
+
+pyst.TrackJob.print_nodes('opencl')
+jobcl = pyst.TrackJob('opencl','0.0',partset.cbuffer,elements.cbuffer)
+
+
+
+
+
+
+
+

--- a/examples/python/track_job_simple.py
+++ b/examples/python/track_job_simple.py
@@ -18,7 +18,7 @@ if __name__ == '__main__':
     # Print enabled architectures; pass any of these values as arch=
     # to the construction of the track job; default == cpu
     print("enabled archs: {0}".format(
-        pyst.TrackJob.enabled_archs().join(', ')))
+        ', '.join(pyst.TrackJob.enabled_archs())))
 
     # =========================================================================
     # CPU based Track Job:

--- a/examples/python/track_job_simple.py
+++ b/examples/python/track_job_simple.py
@@ -5,65 +5,64 @@ import sys
 import pysixtracklib as pyst
 
 if __name__ == '__main__':
-    elements=pyst.Elements()
+    elements = pyst.Elements()
     elements.Drift(length=1.2)
-    elements.Multipole(knl=[0,0.001])
+    elements.Multipole(knl=[0, 0.001])
 
-    partset=pyst.ParticlesSet()
-    particles=partset.Particles(num_particles=100)
+    partset = pyst.ParticlesSet()
+    particles = partset.Particles(num_particles=100)
 
-    particles.px+=range(len(particles.px))
-    particles.px*=1e-2
+    particles.px += range(len(particles.px))
+    particles.px *= 1e-2
 
     # Print enabled architectures; pass any of these values as arch=
     # to the construction of the track job; default == cpu
-    print( "enabled archs: {0}".format(
-        pyst.TrackJob.enabled_archs().join( ', ' ) ) )
+    print("enabled archs: {0}".format(
+        pyst.TrackJob.enabled_archs().join(', ')))
 
     # =========================================================================
     # CPU based Track Job:
 
-    job = pyst.TrackJob(elements.cbuffer,partset.cbuffer)
+    job = pyst.TrackJob(elements.cbuffer, partset.cbuffer)
 
     # Track until every particle is at the begin of turn 5:
-    status = job.track( 5 ) # status should be 0 if successful, otherwise < 0
+    status = job.track(5)  # status should be 0 if successful, otherwise < 0
 
     # Track until every particle is at the begin of turn 10:
-    status = job.track( 10 ) # status should be 0 if successful, otherwise < 0
+    status = job.track(10)  # status should be 0 if successful, otherwise < 0
 
     # prepare the particles buffer for read-out:
     job.collect()
 
     # Track next turn using track_line in two steps:
-    status = job.track_line( 0, 1 ) # Track over the drift, status should be 0
-    status = job.track_line( 1, 2, finish_turn=True ) # finish tracking line
+    status = job.track_line(0, 1)  # Track over the drift, status should be 0
+    status = job.track_line(1, 2, finish_turn=True)  # finish tracking line
 
     del job
 
     # =========================================================================
     # OpenCL based Track Job:
 
-    if "opencl" in set( pyst.TrackJob.enabled_archs() ):
+    if "opencl" in set(pyst.TrackJob.enabled_archs()):
         # Print all available nodes:
-        pyst.TrackJob.print_nodes( "opencl" )
+        pyst.TrackJob.print_nodes("opencl")
 
         job = pyst.TrackJob(elements.cbuffer, partset.cbuffer,
-                            arch="opencl", device_id="0.0" )
+                            arch="opencl", device_id="0.0")
 
         # The particles are still at turn 11 and at element 0 after tracking them
         # with the CPU based track-job; continue tracking!
 
-        status = job.track( 100 ) # track until turn 100
-        status = job.track_line( 0, 1 )
-        status = job.track_line( 1, 2, finish_turn=True )
+        status = job.track(100)  # track until turn 100
+        status = job.track_line(0, 1)
+        status = job.track_line(1, 2, finish_turn=True)
 
         job.collect()
 
         particles_buffer = job.particles_buffer
-        lattice_buffer   = job.beam_elements_buffer
-        output_buffer    = job.output_buffer #Should be None!!!
+        lattice_buffer = job.beam_elements_buffer
+        output_buffer = job.output_buffer  # Should be None!!!
 
         del job
 
-    sys.exit( 0 )
-
+    sys.exit(0)

--- a/examples/python/track_job_simple.py
+++ b/examples/python/track_job_simple.py
@@ -1,28 +1,69 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
+import sys
 import pysixtracklib as pyst
 
-elements=pyst.Elements()
-elements.Drift(length=1.2)
-elements.Multipole(knl=[0,0.001])
+if __name__ == '__main__':
+    elements=pyst.Elements()
+    elements.Drift(length=1.2)
+    elements.Multipole(knl=[0,0.001])
 
-partset=pyst.ParticlesSet()
-particles=partset.Particles(num_particles=100)
+    partset=pyst.ParticlesSet()
+    particles=partset.Particles(num_particles=100)
 
-particles.px+=range(len(particles.px))
-particles.px*=1e-2
+    particles.px+=range(len(particles.px))
+    particles.px*=1e-2
 
-job = pyst.TrackJob(elements.cbuffer,partset.cbuffer)
+    # Print enabled architectures; pass any of these values as arch=
+    # to the construction of the track job; default == cpu
+    print( "enabled archs: {0}".format(
+        pyst.TrackJob.enabled_archs().join( ', ' ) ) )
 
+    # =========================================================================
+    # CPU based Track Job:
 
-pyst.TrackJob.print_nodes('opencl')
-jobcl = pyst.TrackJob('opencl','0.0',partset.cbuffer,elements.cbuffer)
+    job = pyst.TrackJob(elements.cbuffer,partset.cbuffer)
 
+    # Track until every particle is at the begin of turn 5:
+    status = job.track( 5 ) # status should be 0 if successful, otherwise < 0
 
+    # Track until every particle is at the begin of turn 10:
+    status = job.track( 10 ) # status should be 0 if successful, otherwise < 0
 
+    # prepare the particles buffer for read-out:
+    job.collect()
 
+    # Track next turn using track_line in two steps:
+    status = job.track_line( 0, 1 ) # Track over the drift, status should be 0
+    status = job.track_line( 1, 2, finish_turn=True ) # finish tracking line
 
+    del job
 
+    # =========================================================================
+    # OpenCL based Track Job:
 
+    if "opencl" in set( pyst.TrackJob.enabled_archs() ):
+        # Print all available nodes:
+        pyst.TrackJob.print_nodes( "opencl" )
+
+        job = pyst.TrackJob(elements.cbuffer, partset.cbuffer,
+                            arch="opencl", device_id="0.0" )
+
+        # The particles are still at turn 11 and at element 0 after tracking them
+        # with the CPU based track-job; continue tracking!
+
+        status = job.track( 100 ) # track until turn 100
+        status = job.track_line( 0, 1 )
+        status = job.track_line( 1, 2, finish_turn=True )
+
+        job.collect()
+
+        particles_buffer = job.particles_buffer
+        lattice_buffer   = job.beam_elements_buffer
+        output_buffer    = job.output_buffer #Should be None!!!
+
+        del job
+
+    sys.exit( 0 )
 

--- a/python/pysixtracklib/particles.py
+++ b/python/pysixtracklib/particles.py
@@ -4,66 +4,67 @@ import numpy as np
 
 class Particles(CObject):
     _typeid = 1
-    num_particles = CField(0, 'int64',  const=True)
-    q0 = CField(1, 'real',  length='num_particles',
+    num_particles = CField(0, 'int64', const=True)
+    q0 = CField(1, 'real', length='num_particles',
                 default=0.0, pointer=True, alignment=8)
-    mass0 = CField(2, 'real',  length='num_particles',
+    mass0 = CField(2, 'real', length='num_particles',
                    default=0.0, pointer=True, alignment=8)
-    beta0 = CField(3, 'real',  length='num_particles',
+    beta0 = CField(3, 'real', length='num_particles',
                    default=0.0, pointer=True, alignment=8)
-    gamma0 = CField(4, 'real',  length='num_particles',
+    gamma0 = CField(4, 'real', length='num_particles',
                     default=0.0, pointer=True, alignment=8)
-    p0c = CField(5, 'real',  length='num_particles',
+    p0c = CField(5, 'real', length='num_particles',
                  default=0.0, pointer=True, alignment=8)
-    s = CField(6, 'real',  length='num_particles',
+    s = CField(6, 'real', length='num_particles',
                default=0.0, pointer=True, alignment=8)
-    x = CField(7, 'real',  length='num_particles',
+    x = CField(7, 'real', length='num_particles',
                default=0.0, pointer=True, alignment=8)
-    y = CField(8, 'real',  length='num_particles',
+    y = CField(8, 'real', length='num_particles',
                default=0.0, pointer=True, alignment=8)
-    px = CField(9, 'real',  length='num_particles',
+    px = CField(9, 'real', length='num_particles',
                 default=0.0, pointer=True, alignment=8)
-    py = CField(10, 'real',  length='num_particles',
+    py = CField(10, 'real', length='num_particles',
                 default=0.0, pointer=True, alignment=8)
-    zeta = CField(11, 'real',  length='num_particles',
+    zeta = CField(11, 'real', length='num_particles',
                   default=0.0, pointer=True, alignment=8)
-    psigma = CField(12, 'real',  length='num_particles',
+    psigma = CField(12, 'real', length='num_particles',
                     default=0.0, pointer=True, alignment=8)
-    delta = CField(13, 'real',  length='num_particles',
+    delta = CField(13, 'real', length='num_particles',
                    default=0.0, pointer=True, alignment=8)
-    rpp = CField(14, 'real',  length='num_particles',
+    rpp = CField(14, 'real', length='num_particles',
                  default=1.0, pointer=True, alignment=8)
-    rvv = CField(15, 'real',  length='num_particles',
+    rvv = CField(15, 'real', length='num_particles',
                  default=1.0, pointer=True, alignment=8)
-    chi = CField(16, 'real',  length='num_particles',
+    chi = CField(16, 'real', length='num_particles',
                  default=0.0, pointer=True, alignment=8)
-    charge_ratio = CField(17, 'real',  length='num_particles',
+    charge_ratio = CField(17, 'real', length='num_particles',
                           default=1.0, pointer=True, alignment=8)
     particle_id = CField(18, 'int64', length='num_particles',
-                         default=-1,  pointer=True, alignment=8)
+                         default=-1, pointer=True, alignment=8)
     at_element = CField(19, 'int64', length='num_particles',
-                        default=-1,  pointer=True, alignment=8)
+                        default=-1, pointer=True, alignment=8)
     at_turn = CField(20, 'int64', length='num_particles',
-                     default=-1,  pointer=True, alignment=8)
+                     default=-1, pointer=True, alignment=8)
     state = CField(21, 'int64', length='num_particles',
-                   default=1,   pointer=True, alignment=8)
+                   default=1, pointer=True, alignment=8)
 
     def __init__(self, **kwargs):
         CObject.__init__(self, **kwargs)
 
-    sigma = property(lambda self: (self.beta0/self.beta)*self.zeta)
-    beta = property(lambda p:  (1+p.delta)/(1/p.beta0+p.ptau))
+    sigma = property(lambda self: (self.beta0 / self.beta) * self.zeta)
+    beta = property(lambda p: (1 + p.delta) / (1 / p.beta0 + p.ptau))
 
     @property
     def ptau(self):
-        return np.sqrt(self.delta**2+2*self.delta + 1/self.beta0**2)-1/self.beta0
+        return np.sqrt(self.delta**2 + 2 * self.delta +
+                       1 / self.beta0**2) - 1 / self.beta0
 
     def set_reference(self, p0c=7e12, mass0=938.272046e6, q0=1):
         self.q0 = 1
         self.mass0 = mass0
-        energy0 = np.sqrt(p0c**2+mass0**2)
-        self.beta0 = p0c/energy0
-        self.gamma0 = energy0/mass0
+        energy0 = np.sqrt(p0c**2 + mass0**2)
+        self.beta0 = p0c / energy0
+        self.gamma0 = energy0 / mass0
         self.p0c = p0c
         self.particle_id = np.arange(self.num_particles)
         return self
@@ -128,13 +129,30 @@ class Particles(CObject):
 
 
 def makeCopy(orig, cbuffer=None):
-    p = Particles(cbuffer=cbuffer, num_particles=orig.num_particles,
-                  q0=orig.q0, mass0=orig.mass0, beta0=orig.beta0, gamma0=orig.gamma0,
-                  p0c=orig.p0c, s=orig.s, x=orig.x, y=orig.y, px=orig.px, py=orig.py,
-                  zeta=orig.zeta, delta=orig.delta, psigma=orig.psigma, rpp=orig.rpp,
-                  rvv=orig.rvv, chi=orig.chi, charge_ratio=orig.charge_ratio,
-                  particle_id=orig.particle_id, at_element=orig.at_element,
-                  at_turn=orig.at_turn, state=orig.state)
+    p = Particles(
+        cbuffer=cbuffer,
+        num_particles=orig.num_particles,
+        q0=orig.q0,
+        mass0=orig.mass0,
+        beta0=orig.beta0,
+        gamma0=orig.gamma0,
+        p0c=orig.p0c,
+        s=orig.s,
+        x=orig.x,
+        y=orig.y,
+        px=orig.px,
+        py=orig.py,
+        zeta=orig.zeta,
+        delta=orig.delta,
+        psigma=orig.psigma,
+        rpp=orig.rpp,
+        rvv=orig.rvv,
+        chi=orig.chi,
+        charge_ratio=orig.charge_ratio,
+        particle_id=orig.particle_id,
+        at_element=orig.at_element,
+        at_turn=orig.at_turn,
+        state=orig.state)
 
     return p
 

--- a/python/pysixtracklib/stcommon.py
+++ b/python/pysixtracklib/stcommon.py
@@ -299,7 +299,7 @@ st_OutputBuffer_required_for_tracking.argptypes = [
     ct.c_uint64]
 
 st_OutputBuffer_required_for_tracking_of_particle_sets = \
-    sixtracklib.st_OutputBuffer_required_for_tracking_of_particle_sets_ext
+    sixtracklib.st_OutputBuffer_required_for_tracking_of_particle_sets
 st_OutputBuffer_required_for_tracking_of_particle_sets.restype = ct.c_int32
 st_OutputBuffer_required_for_tracking_of_particle_sets.argptypes = [
     st_Buffer_p,

--- a/python/pysixtracklib/stcommon.py
+++ b/python/pysixtracklib/stcommon.py
@@ -11,7 +11,6 @@ st_Null = ct.cast(0, ct.c_void_p)
 st_NullChar = ct.cast(0, ct.c_char_p)
 
 st_Context_p = ct.c_void_p
-st_TrackJob_p = ct.c_void_p
 st_uint64_p = ct.POINTER(ct.c_uint64)
 st_uchar_p = ct.POINTER(ct.c_ubyte)
 
@@ -276,6 +275,39 @@ st_BeamMonitor_assign_output_buffer_from_offset.argtypes = [
 # -----------------------------------------------------------------------------
 # OutputBuffer bindings
 
+st_OutputBuffer_requires_output_buffer = \
+    sixtracklib.st_OutputBuffer_requires_output_buffer_ext
+st_OutputBuffer_requires_output_buffer.restype = ct.c_bool
+st_OutputBuffer_requires_output_buffer.argtypes = [ct.c_int32]
+
+st_OutputBuffer_requires_beam_monitor_output = \
+    sixtracklib.st_OutputBuffer_requires_beam_monitor_output_ext
+st_OutputBuffer_requires_beam_monitor_output.restype = ct.c_bool
+st_OutputBuffer_requires_beam_monitor_output.argtypes = [ct.c_int32]
+
+st_OutputBuffer_requires_elem_by_elem_output = \
+    sixtracklib.st_OutputBuffer_requires_elem_by_elem_output_ext
+st_OutputBuffer_requires_elem_by_elem_output.restype = ct.c_bool
+st_OutputBuffer_requires_elem_by_elem_output.argtypes = [ct.c_int32]
+
+st_OutputBuffer_required_for_tracking = \
+    sixtracklib.st_OutputBuffer_required_for_tracking
+st_OutputBuffer_required_for_tracking.restype = ct.c_int32
+st_OutputBuffer_required_for_tracking.argptypes = [
+    st_Particles_p,
+    st_Buffer_p,
+    ct.c_uint64]
+
+st_OutputBuffer_required_for_tracking_of_particle_sets = \
+    sixtracklib.st_OutputBuffer_required_for_tracking_of_particle_sets_ext
+st_OutputBuffer_required_for_tracking_of_particle_sets.restype = ct.c_int32
+st_OutputBuffer_required_for_tracking_of_particle_sets.argptypes = [
+    st_Buffer_p,
+    ct.c_uint64,
+    st_uint64_p,
+    st_Buffer_p,
+    ct.c_uint64]
+
 st_OutputBuffer_prepare = sixtracklib.st_OutputBuffer_prepare
 st_OutputBuffer_prepare.restype = ct.c_int32
 st_OutputBuffer_prepare.argtypes = [
@@ -391,6 +423,9 @@ def st_OutputBuffer_create_output_cbuffer(
 # TrackJob objects
 
 
+st_TrackJob_p = ct.c_void_p
+st_NullTrackJob = ct.cast(0, st_TrackJob_p)
+
 st_TrackJob_create = sixtracklib.st_TrackJobCpu_create
 st_TrackJob_create.argtypes = [ct.c_char_p, ct.c_char_p]
 st_TrackJob_create.restype = st_TrackJob_p
@@ -421,6 +456,15 @@ st_TrackJob_track_until.restype = ct.c_int32
 st_TrackJob_track_elem_by_elem = sixtracklib.st_TrackJob_track_elem_by_elem
 st_TrackJob_track_elem_by_elem.argtypes = [st_TrackJob_p, ct.c_uint64]
 st_TrackJob_track_elem_by_elem.restype = ct.c_int32
+
+
+st_TrackJob_track_line = sixtracklib.st_TrackJob_track_line
+st_TrackJob_track_line.restype = ct.c_int32
+st_TrackJob_track_line.argtypes = [
+    st_TrackJob_p,
+    ct.c_uint64,
+    ct.c_uint64,
+    ct.c_bool]
 
 
 st_TrackJob_collect = sixtracklib.st_TrackJob_collect

--- a/python/pysixtracklib/trackjob.py
+++ b/python/pysixtracklib/trackjob.py
@@ -32,13 +32,13 @@ class TrackJob(object):
             print("architecture {0} is not enabled/known".format(arch_str))
 
     def __init__(self,
-                beam_elements_buffer,
-                particles_buffer,
-                until_turn_elem_by_elem=0,
-                arch='cpu',
-                device_id=None,
-                output_buffer=None,
-                config_str=None):
+                 beam_elements_buffer,
+                 particles_buffer,
+                 until_turn_elem_by_elem=0,
+                 arch='cpu',
+                 device_id=None,
+                 output_buffer=None,
+                 config_str=None):
         self.ptr_st_track_job = st.st_NullTrackJob
         self._particles_buffer = None
         self._ptr_c_particles_buffer = st.st_NullBuffer
@@ -62,26 +62,27 @@ class TrackJob(object):
             self._ptr_c_beam_elements_buffer = \
                 st.st_Buffer_new_mapped_on_cbuffer(beam_elements_buffer)
             if self._ptr_c_beam_elements_buffer == st.st_NullBuffer:
-                raise ValueError( "Issues with input beam elements buffer" )
+                raise ValueError("Issues with input beam elements buffer")
 
         particles = st.st_Particles_buffer_get_particles(
-            self._ptr_c_particles_buffer,0)
+            self._ptr_c_particles_buffer, 0)
 
         if particles == st.st_NullParticles:
-            raise ValueError( "Required particle sets not available" )
+            raise ValueError("Required particle sets not available")
 
         until_turn_elem_by_elem = ct.c_uint64(until_turn_elem_by_elem)
         out_buffer_flags = st.st_OutputBuffer_required_for_tracking(
-            particles,self._ptr_c_beam_elements_buffer,until_turn_elem_by_elem)
+            particles, self._ptr_c_beam_elements_buffer, until_turn_elem_by_elem)
         needs_output_buffer = st.st_OutputBuffer_requires_output_buffer(
             ct.c_int32(out_buffer_flags))
 
-        if  needs_output_buffer:
+        if needs_output_buffer:
             num_objects = ct.c_uint64(0)
             num_slots = ct.c_uint64(0)
             num_dataptrs = ct.c_uint64(0)
             num_garbage = ct.c_uint64(0)
-            slot_size = st.st_Buffer_get_slot_size(self._ptr_c_particles_buffer)
+            slot_size = st.st_Buffer_get_slot_size(
+                self._ptr_c_particles_buffer)
 
             ret = st.st_OutputBuffer_calculate_output_buffer_params(
                 self._ptr_c_beam_elements_buffer, particles,
@@ -91,7 +92,7 @@ class TrackJob(object):
 
             if ret == 0:
                 if num_objects.value > 0 and num_slots.value > 0 and \
-                    num_dataptrs.value > 0 and num_garbage.value >= 0:
+                        num_dataptrs.value > 0 and num_garbage.value >= 0:
                     if output_buffer is None:
                         output_buffer = CBuffer(
                             max_slots=num_slots.value,
@@ -106,30 +107,30 @@ class TrackJob(object):
                             max_garbage=num_garbage.value)
 
                     if output_buffer is None:
-                        raise ValueError( "Could not provide output buffer" )
+                        raise ValueError("Could not provide output buffer")
 
                 self._output_buffer = output_buffer
                 self._ptr_c_output_buffer = \
-                    st.st_Buffer_new_mapped_on_cbuffer( output_buffer )
+                    st.st_Buffer_new_mapped_on_cbuffer(output_buffer)
                 if self._ptr_c_output_buffer == st.st_NullBuffer:
-                    raise ValueError( "Unable to map (optional) output buffer" )
+                    raise ValueError("Unable to map (optional) output buffer")
             else:
-                raise ValueError( "Error pre-calculating out buffer params" )
+                raise ValueError("Error pre-calculating out buffer params")
         elif output_buffer is not None:
             self._output_buffer = output_buffer
             self._ptr_c_output_buffer = \
-                st.st_Buffer_new_mapped_on_cbuffer( self._output_buffer )
+                st.st_Buffer_new_mapped_on_cbuffer(self._output_buffer)
             if self._ptr_c_output_buffer == st.st_NullBuffer:
-                raise ValueError( "Unable to map (optional) output buffer" )
+                raise ValueError("Unable to map (optional) output buffer")
 
         assert((needs_output_buffer and
-                self._ptr_c_output_buffer != st.st_NullBuffer ) or
-               ( not needs_output_buffer ))
+                self._ptr_c_output_buffer != st.st_NullBuffer) or
+               (not needs_output_buffer))
 
         arch = arch.strip().lower()
-        if not( stconf.SIXTRACKLIB_MODULES.get( arch, False) is not False
-                or arch == 'cpu' ):
-            raise ValueError( "Unknown architecture {0}".format( arch, ) )
+        if not(stconf.SIXTRACKLIB_MODULES.get(arch, False) is not False
+                or arch == 'cpu'):
+            raise ValueError("Unknown architecture {0}".format(arch, ))
 
         if device_id is not None:
             if config_str is None:
@@ -150,7 +151,6 @@ class TrackJob(object):
         if self.ptr_st_track_job == st.st_NullTrackJob:
             raise ValueError('unable to construct TrackJob from arguments')
 
-
     def __del__(self):
         if self.ptr_st_track_job != st.st_NullTrackJob:
             job_owns_output_buffer = st.st_TrackJob_owns_output_buffer(
@@ -160,8 +160,8 @@ class TrackJob(object):
             self.ptr_st_track_job = st.st_NullTrackJob
 
             if job_owns_output_buffer and \
-                self._ptr_c_output_buffer != st.st_NullBuffer:
-                self._ptr_c_output_buffer  = st.st_NullBuffer
+                    self._ptr_c_output_buffer != st.st_NullBuffer:
+                self._ptr_c_output_buffer = st.st_NullBuffer
 
         if self._ptr_c_particles_buffer != st.st_NullBuffer:
             st.st_Buffer_delete(self._ptr_c_particles_buffer)
@@ -195,7 +195,7 @@ class TrackJob(object):
         return st.st_TrackJob_track_elem_by_elem(
             self.ptr_st_track_job, ct.c_uint64(until_turn))
 
-    def track_line(self,begin_idx,end_idx,finish_turn=False):
+    def track_line(self, begin_idx, end_idx, finish_turn=False):
         return st.st_TrackJob_track_line(
             self.ptr_st_track_job,
             ct.c_uint64(begin_idx),

--- a/python/pysixtracklib/trackjob.py
+++ b/python/pysixtracklib/trackjob.py
@@ -39,11 +39,11 @@ class TrackJob(object):
                 device_id_str=None,
                 output_buffer=None,
                 config_str=None):
-        self.ptr_st_track_job = st.st_Null
+        self.ptr_st_track_job = st.st_NullTrackJob
         self._particles_buffer = None
-        self._ptr_c_particles_buffer = st.st_Null
+        self._ptr_c_particles_buffer = st.st_NullBuffer
         self._beam_elements_buffer = None
-        self._ptr_c_beam_elements_buffer = st.st_Null
+        self._ptr_c_beam_elements_buffer = st.st_NullBuffer
         self._output_buffer = None
         self._ptr_c_output_buffer = st.st_NullBuffer
 
@@ -52,35 +52,36 @@ class TrackJob(object):
 
         if particles_buffer is not None:
             self._particles_buffer = particles_buffer
-            ptr = ct.cast(particles_buffer.base, base_addr_t)
-            nn = ct.c_uint64(particles_buffer.size)
-            self._ptr_c_particles_buffer = st.st_Buffer_new_on_data(ptr, nn)
-            success = bool(self._ptr_c_particles_buffer != st.st_Null)
+            self._ptr_c_particles_buffer = \
+                st.st_Buffer_new_mapped_on_cbuffer(particles_buffer)
+            if self._ptr_c_particles_buffer == st.st_NullBuffer:
+                raise ValueError("Issues with input particles buffer")
 
-        if success and beam_elements_buffer is not None:
+        if beam_elements_buffer is not None:
             self._beam_elements_buffer = beam_elements_buffer
-            ptr = ct.cast(beam_elements_buffer.base, base_addr_t)
-            nn = ct.c_uint64(beam_elements_buffer.size)
-            self._ptr_c_beam_elements_buffer = st.st_Buffer_new_on_data(
-                ptr, nn)
-            success = bool(self._ptr_c_beam_elements_buffer != st.st_Null)
+            self._ptr_c_beam_elements_buffer = \
+                st.st_Buffer_new_mapped_on_cbuffer(beam_elements_buffer)
+           if self._ptr_c_beam_elements_buffer == st.st_NullBuffer:
+               raise ValueError( "Issues with input beam elements buffer" )
 
-        if success and self._ptr_c_particles_buffer != st.st_Null and \
-                self._ptr_c_beam_elements_buffer != st.st_Null:
+        particles = st.st_Particles_buffer_get_particles(
+            self._ptr_c_particles_buffer,0)
 
-            particles = st.st_Particles_buffer_get_particles(
-                self._ptr_c_particles_buffer, 0)
+        if particles == st.st_NullParticles:
+            raise ValueError( "Required particle sets not available" )
 
-            success = bool(particles != st.st_NullParticles)
+        until_turn_elem_by_elem = ct.c_uint64(until_turn_elem_by_elem)
+        out_buffer_flags = st.st_OutputBuffer_required_for_tracking(
+            particles,self._ptr_c_beam_elements_buffer,until_turn_elem_by_elem)
+        needs_output_buffer = st.st_OutputBuffer_requires_output_buffer(
+            ct.c_int32(out_buffer_flags))
 
+        if  needs_output_buffer:
             num_objects = ct.c_uint64(0)
             num_slots = ct.c_uint64(0)
             num_dataptrs = ct.c_uint64(0)
             num_garbage = ct.c_uint64(0)
-            until_turn_elem_by_elem = ct.c_uint64(until_turn_elem_by_elem)
-
-            slot_size = st.st_Buffer_get_slot_size(
-                self._ptr_c_particles_buffer)
+            slot_size = st.st_Buffer_get_slot_size(self._ptr_c_particles_buffer)
 
             ret = st.st_OutputBuffer_calculate_output_buffer_params(
                 self._ptr_c_beam_elements_buffer, particles,
@@ -88,54 +89,67 @@ class TrackJob(object):
                 ct.byref(num_slots), ct.byref(num_dataptrs),
                 ct.byref(num_garbage), slot_size)
 
-            if num_objects.value>0: #no outbuffer needed
-               if success and ret == 0 and \
-                       num_objects.value > 0 and num_slots.value > 0 and \
-                       num_dataptrs.value > 0 and num_garbage.value >= 0:
-                   if output_buffer is None:
-                       output_buffer = CBuffer(max_slots=num_slots.value,
-                                               max_objects=num_objects.value,
-                                               max_pointers=num_dataptrs.value,
-                                               max_garbage=num_garbage.value)
-                   else:
-                       output_buffer.allocate(max_slots=num_slots.value,
-                                              max_objects=num_objects.value,
-                                              max_pointers=num_dataptrs.value,
-                                              max_garbage=num_garbage.value)
+            if ret == 0
+                if num_objects.value > 0 and num_slots.value > 0 and \
+                    num_dataptrs.value > 0 and num_garbage.value >= 0:
+                    if output_buffer is None:
+                        output_buffer = CBuffer(
+                            max_slots=num_slots.value,
+                            max_objects=num_objects.value,
+                            max_pointers=num_dataptrs.value,
+                            max_garbage=num_garbage.value)
+                    else:
+                        output_buffer.reallocate(
+                            max_slots=num_slots.value,
+                            max_objects=num_objects.value,
+                            max_pointers=num_dataptrs.value,
+                            max_garbage=num_garbage.value)
 
-                   assert(output_buffer is not None)
-                   self._output_buffer = output_buffer
-                   ptr = ct.cast(output_buffer.base, base_addr_t)
-                   nn = ct.c_uint64(output_buffer.size)
-                   self._ptr_c_output_buffer = st.st_Buffer_new_on_data(ptr, nn)
-                   success = bool(self._ptr_c_output_buffer != st.st_NullBuffer)
-               elif ret != 0:
-                   success = False
+                    if output_buffer is None:
+                        raise ValueError( "Could not provide output buffer" )
 
-        if success:
-            arch_str = arch_str.strip().lower()
-            success = bool(stconf.SIXTRACKLIB_MODULES.get(
-                arch_str, False) or arch_str == 'cpu')
-
-        if success:
-            if device_id_str is not None:
-                if config_str is None:
-                    config_str = device_id_str
-                else:
-                    config_str = device_id_str + ";" + config_str
+                self._output_buffer = output_buffer
+                self._ptr_c_output_buffer = \
+                    st.st_Buffer_new_mapped_on_cbuffer( output_buffer )
+                if self._ptr_c_output_buffer == st.st_NullBuffer:
+                    raise ValueError( "Unable to map (optional) output buffer" )
             else:
-                config_str = ""
+                raise ValueError( "Error precalculating output buffer params" )
+        elif output_buffer is not None:
+            self._output_buffer = output_buffer
+            self._ptr_c_output_buffer = \
+                st.st_Buffer_new_mapped_on_cbuffer( self._output_buffer )
+            if self._ptr_c_output_buffer == st.st_NullBuffer:
+                raise ValueError( "Unable to map (optional) output buffer" )
 
-            arch_str = arch_str.encode('utf-8')
-            config_str = config_str.encode('utf-8')
+        assert((requires_output_buffer and
+                self._ptr_c_output_buffer != st.st_NullBuffer ) or
+               ( not requires_output_buffer ))
 
-            self.ptr_st_track_job = st.st_TrackJob_new_with_output(
-                ct.c_char_p(arch_str), self._ptr_c_particles_buffer,
-                self._ptr_c_beam_elements_buffer, self._ptr_c_output_buffer,
-                until_turn_elem_by_elem, ct.c_char_p(config_str))
+        arch_str = arch_str.strip().lower()
+        if not( stconf.SIXTRACKLIB_MODULES.get( arch_str, False) or
+               arch_str == 'cpu' ):
+            raise ValueError( "Unknown architecture" )
 
-        if not success or self.ptr_st_track_job == st.st_Null:
+        if device_id_str is not None:
+            if config_str is None:
+                config_str = device_id_str
+            else:
+                config_str = device_id_str + ";" + config_str
+        else:
+            config_str = ""
+
+        arch_str = arch_str.encode('utf-8')
+        config_str = config_str.encode('utf-8')
+
+        self.ptr_st_track_job = st.st_TrackJob_new_with_output(
+            ct.c_char_p(arch_str), self._ptr_c_particles_buffer,
+            self._ptr_c_beam_elements_buffer, self._ptr_c_output_buffer,
+            until_turn_elem_by_elem, ct.c_char_p(config_str))
+
+        if self.ptr_st_track_job == st.st_NullTrackJob:
             raise ValueError('unable to construct TrackJob from arguments')
+
 
     def __del__(self):
         if self.ptr_st_track_job != st.st_Null:
@@ -180,6 +194,13 @@ class TrackJob(object):
     def track_elem_by_elem(self, until_turn):
         return st.st_TrackJob_track_elem_by_elem(
             self.ptr_st_track_job, ct.c_uint64(until_turn))
+
+    def track_line(self,begin_idx,end_idx,finish_turn=False):
+        return st.st_TrackJob_track_line(
+            self.ptr_st_track_job,
+            ct.c_uint64(begin_idx),
+            ct.c_uint64(end_idx),
+            ct.c_bool(finish_turn))
 
     def collect(self):
         st.st_TrackJob_collect(self.ptr_st_track_job)

--- a/python/pysixtracklib/trackjob.py
+++ b/python/pysixtracklib/trackjob.py
@@ -31,9 +31,14 @@ class TrackJob(object):
         else:
             print("architecture {0} is not enabled/known".format(arch_str))
 
-    def __init__(self, arch_str, device_id_str=None, particles_buffer=None,
-                 beam_elements_buffer=None, output_buffer=None,
-                 until_turn_elem_by_elem=0, config_str=None):
+    def __init__(self,
+                beam_elements_buffer,
+                particles_buffer,
+                until_turn_elem_by_elem=0,
+                arch_str='cpu',
+                device_id_str=None,
+                output_buffer=None,
+                config_str=None):
         self.ptr_st_track_job = st.st_Null
         self._particles_buffer = None
         self._ptr_c_particles_buffer = st.st_Null

--- a/sixtracklib/common/output/output_buffer.c
+++ b/sixtracklib/common/output/output_buffer.c
@@ -23,9 +23,25 @@
     #include "sixtracklib/common/particles.h"
 #endif /* !defined( SIXTRL_NO_INCLUDES ) */
 
+bool NS(OutputBuffer_requires_output_buffer_ext)(
+    NS(output_buffer_flag_t) const flags )
+{
+    return NS(OutputBuffer_requires_output_buffer)( flags );
+}
 
-SIXTRL_HOST_FN NS(output_buffer_flag_t)
-NS(OutputBuffer_required_for_tracking)(
+bool NS(OutputBuffer_requires_elem_by_elem_output_ext)(
+    NS(output_buffer_flag_t) const flags )
+{
+    return NS(OutputBuffer_requires_elem_by_elem_output)( flags );
+}
+
+bool NS(OutputBuffer_requires_beam_monitor_output_ext)(
+    NS(output_buffer_flag_t) const flags )
+{
+    return NS(OutputBuffer_requires_beam_monitor_output)( flags );
+}
+
+NS(output_buffer_flag_t) NS(OutputBuffer_required_for_tracking)(
     SIXTRL_PARTICLE_ARGPTR_DEC const NS(Particles) *const SIXTRL_RESTRICT p,
     SIXTRL_BUFFER_ARGPTR_DEC const NS(Buffer) *const
         SIXTRL_RESTRICT belem_buffer,
@@ -190,7 +206,7 @@ NS(output_buffer_flag_t) NS(OutputBuffer_required_for_tracking_detailed)(
 
 /* ------------------------------------------------------------------------- */
 
-SIXTRL_HOST_FN int NS(OutputBuffer_prepare)(
+int NS(OutputBuffer_prepare)(
     SIXTRL_BUFFER_ARGPTR_DEC NS(Buffer)* SIXTRL_RESTRICT belements,
     SIXTRL_BUFFER_ARGPTR_DEC NS(Buffer)* SIXTRL_RESTRICT output_buffer,
     SIXTRL_PARTICLE_ARGPTR_DEC const NS(Particles) *const SIXTRL_RESTRICT p,
@@ -346,7 +362,7 @@ int NS(OutputBuffer_prepare_detailed)(
 
 /* - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - */
 
-SIXTRL_HOST_FN int NS(OutputBuffer_calculate_output_buffer_params)(
+int NS(OutputBuffer_calculate_output_buffer_params)(
     SIXTRL_BUFFER_ARGPTR_DEC const NS(Buffer) *const SIXTRL_RESTRICT belements,
     SIXTRL_PARTICLE_ARGPTR_DEC const NS(Particles) *const SIXTRL_RESTRICT p,
     NS(buffer_size_t) const until_turn_elem_by_elem,
@@ -378,7 +394,7 @@ SIXTRL_HOST_FN int NS(OutputBuffer_calculate_output_buffer_params)(
 
 /* - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - */
 
-SIXTRL_HOST_FN int
+int
 NS(OutputBuffer_calculate_output_buffer_params_for_particles_sets)(
     SIXTRL_BUFFER_ARGPTR_DEC const NS(Buffer) *const SIXTRL_RESTRICT belements,
     SIXTRL_BUFFER_ARGPTR_DEC const NS(Buffer) *const SIXTRL_RESTRICT pbuffer,
@@ -414,7 +430,7 @@ NS(OutputBuffer_calculate_output_buffer_params_for_particles_sets)(
 
 /* - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - */
 
-SIXTRL_HOST_FN int NS(OutputBuffer_calculate_output_buffer_params_detailed)(
+int NS(OutputBuffer_calculate_output_buffer_params_detailed)(
     SIXTRL_BUFFER_ARGPTR_DEC const NS(Buffer) *const SIXTRL_RESTRICT belements,
     NS(particle_index_t) const min_part_id,
     NS(particle_index_t) const max_part_id,

--- a/sixtracklib/common/output/output_buffer.h
+++ b/sixtracklib/common/output/output_buffer.h
@@ -47,6 +47,19 @@ SIXTRL_STATIC SIXTRL_FN bool NS(OutputBuffer_requires_beam_monitor_output)(
 
 #if !defined( _GPUCODE )
 
+SIXTRL_EXTERN SIXTRL_HOST_FN bool NS(OutputBuffer_requires_output_buffer_ext)(
+    NS(output_buffer_flag_t) const flags );
+
+SIXTRL_EXTERN SIXTRL_HOST_FN bool
+NS(OutputBuffer_requires_elem_by_elem_output_ext)(
+    NS(output_buffer_flag_t) const flags );
+
+SIXTRL_EXTERN SIXTRL_HOST_FN bool
+NS(OutputBuffer_requires_beam_monitor_output_ext)(
+    NS(output_buffer_flag_t) const flags );
+
+/* - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - */
+
 SIXTRL_STATIC_VAR NS(output_buffer_flag_t) const NS(OUTPUT_BUFFER_NONE) =
         ( NS(output_buffer_flag_t) )SIXTRL_OUTPUT_BUFFER_NONE;
 

--- a/tests/python/.gitignore
+++ b/tests/python/.gitignore
@@ -1,0 +1,2 @@
+Testing
+Testing/*

--- a/tests/python/CMakeLists.txt
+++ b/tests/python/CMakeLists.txt
@@ -21,6 +21,14 @@ if( SIXTRACKL_ENABLE_PROGRAMM_TESTS )
         WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}/python )
 
     # -------------------------------------------------------------------------
+    # test_track_job_setup:
+
+    add_test( NAME Python_TrackJobSetupTests
+        COMMAND ${PYTHON_EXECUTABLE}
+                ${CMAKE_CURRENT_SOURCE_DIR}/test_track_job_setup.py
+        WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}/python )
+
+    # -------------------------------------------------------------------------
     # test_track_job_cpu:
 
     add_test( NAME Python_TrackJobCpuTests
@@ -37,6 +45,5 @@ if( SIXTRACKL_ENABLE_PROGRAMM_TESTS )
          WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}/python )
 
 endif()
-
 
 #end: tests/python/CMakeLists.txt

--- a/tests/python/test_track_job_cpu.py
+++ b/tests/python/test_track_job_cpu.py
@@ -101,9 +101,7 @@ if __name__ == '__main__':
     track_pb = CBuffer()
     track_particles = pyst.makeCopy(initial_particles, cbuffer=track_pb)
 
-    job = pyst.TrackJob("cpu",
-                        particles_buffer=track_pb, beam_elements_buffer=eb,
-                        until_turn_elem_by_elem=until_turn_elem_by_elem)
+    job = pyst.TrackJob( eb, track_pb, until_turn_elem_by_elem )
 
     assert(job.type_str() == 'cpu')
     assert(job.has_output_buffer())
@@ -122,30 +120,19 @@ if __name__ == '__main__':
     output_buffer = job.output_buffer
     particles_buffer = job.particles_buffer
 
-    assert(output_buffer.n_objects == 3)
+    assert(output_buffer.size > 0)
+    assert(output_buffer.n_objects > 0)
 
-    ptr_output_buffer = st_Buffer_new_mapped_on_cbuffer(output_buffer)
-    ptr_cmp_output_buffer = st_Buffer_new_mapped_on_cbuffer(cmp_output_buffer)
-    ABS_DIFF = ct.c_double(2e-14)
+    assert(cmp_output_buffer.n_objects == output_buffer.n_objects)
+    assert(cmp_output_buffer.base != output_buffer.base)
 
-    if(0 != st_Particles_buffers_compare_values_with_treshold(
-            ptr_output_buffer, ptr_cmp_output_buffer, ABS_DIFF)):
+    nn = cmp_output_buffer.n_objects
+    ABS_DIFF = 2e-14
 
-        nn = output_buffer.n_objects
-
-        for ii in range(nn):
-            assert(0 == st_Particles_compare_values_with_treshold(
-                st_Particles_cbuffer_get_particles(output_buffer, 0),
-                st_Particles_cbuffer_get_particles(cmp_output_buffer, 0),
-                ABS_DIFF))
-
-    assert(0 == st_Particles_buffers_compare_values_with_treshold(
-        ptr_output_buffer, ptr_cmp_output_buffer, ABS_DIFF))
-
-    st_Buffer_delete(ptr_output_buffer)
-    st_Buffer_delete(ptr_cmp_output_buffer)
-
-    ptr_output_buffer = pyst.stcommon.st_NullBuffer
-    ptr_cmp_output_buffer = pyst.stcommon.st_NullBuffer
+    for ii in range(nn):
+        cmp_particles = cmp_output_buffer.get_object(ii, pyst.Particles)
+        particles = output_buffer.get_object(ii, pyst.Particles)
+        assert(0 == pyst.particles.compareParticlesDifference(
+            cmp_particles, particles, abs_treshold=ABS_DIFF))
 
     sys.exit(0)

--- a/tests/python/test_track_job_cpu.py
+++ b/tests/python/test_track_job_cpu.py
@@ -101,7 +101,7 @@ if __name__ == '__main__':
     track_pb = CBuffer()
     track_particles = pyst.makeCopy(initial_particles, cbuffer=track_pb)
 
-    job = pyst.TrackJob( eb, track_pb, until_turn_elem_by_elem )
+    job = pyst.TrackJob(eb, track_pb, until_turn_elem_by_elem)
 
     assert(job.type_str() == 'cpu')
     assert(job.has_output_buffer())

--- a/tests/python/test_track_job_cpu.py
+++ b/tests/python/test_track_job_cpu.py
@@ -106,7 +106,7 @@ if __name__ == '__main__':
     assert(job.type_str() == 'cpu')
     assert(job.has_output_buffer())
     assert(job.num_beam_monitors() > 0)
-    assert(job.has_elem_by_elem_outupt())
+    assert(job.has_elem_by_elem_output())
     assert(job.has_beam_monitor_output())
 
     status = job.track_elem_by_elem(until_turn_elem_by_elem)

--- a/tests/python/test_track_job_opencl.py
+++ b/tests/python/test_track_job_opencl.py
@@ -111,7 +111,7 @@ if __name__ == '__main__':
     assert(job.type_str() == 'opencl')
     assert(job.has_output_buffer())
     assert(job.num_beam_monitors() > 0)
-    assert(job.has_elem_by_elem_outupt())
+    assert(job.has_elem_by_elem_output())
     assert(job.has_beam_monitor_output())
 
     status = job.track_elem_by_elem(until_turn_elem_by_elem)

--- a/tests/python/test_track_job_opencl.py
+++ b/tests/python/test_track_job_opencl.py
@@ -66,8 +66,8 @@ if __name__ == '__main__':
     cmp_particles = pyst.makeCopy(initial_particles, cbuffer=cmp_track_pb)
 
     cmp_output_buffer, elem_by_elem_offset, output_offset, min_turn_id = \
-        st_OutputBuffer_create_output_cbuffer(eb,
-                                              cmp_track_pb, until_turn_elem_by_elem=until_turn_elem_by_elem)
+        st_OutputBuffer_create_output_cbuffer(eb, cmp_track_pb,
+            until_turn_elem_by_elem=until_turn_elem_by_elem)
 
     assert(cmp_output_buffer.n_objects == 3)
     assert(elem_by_elem_offset == 0)
@@ -102,12 +102,9 @@ if __name__ == '__main__':
     track_pb = CBuffer()
     track_particles = pyst.makeCopy(initial_particles, cbuffer=track_pb)
 
-    track_pb = CBuffer()
-    track_particles = pyst.makeCopy(initial_particles, cbuffer=track_pb)
-
-    job = pyst.TrackJob("opencl", device_id_str="0.0",
-                        particles_buffer=track_pb, beam_elements_buffer=eb,
-                        until_turn_elem_by_elem=until_turn_elem_by_elem)
+    arch = "opencl"
+    device = "0.0"
+    job = pyst.TrackJob( eb, track_pb, until_turn_elem_by_elem, arch, device )
 
     print("job setup complete")
 
@@ -148,7 +145,5 @@ if __name__ == '__main__':
         particles = output_buffer.get_object(ii, pyst.Particles)
         assert(0 == pyst.particles.compareParticlesDifference(
             cmp_particles, particles, abs_treshold=ABS_DIFF))
-
-    print("compare finished")
 
     sys.exit(0)

--- a/tests/python/test_track_job_opencl.py
+++ b/tests/python/test_track_job_opencl.py
@@ -67,7 +67,7 @@ if __name__ == '__main__':
 
     cmp_output_buffer, elem_by_elem_offset, output_offset, min_turn_id = \
         st_OutputBuffer_create_output_cbuffer(eb, cmp_track_pb,
-            until_turn_elem_by_elem=until_turn_elem_by_elem)
+                                              until_turn_elem_by_elem=until_turn_elem_by_elem)
 
     assert(cmp_output_buffer.n_objects == 3)
     assert(elem_by_elem_offset == 0)
@@ -104,7 +104,7 @@ if __name__ == '__main__':
 
     arch = "opencl"
     device = "0.0"
-    job = pyst.TrackJob( eb, track_pb, until_turn_elem_by_elem, arch, device )
+    job = pyst.TrackJob(eb, track_pb, until_turn_elem_by_elem, arch, device)
 
     print("job setup complete")
 

--- a/tests/python/test_track_job_setup.py
+++ b/tests/python/test_track_job_setup.py
@@ -1,0 +1,202 @@
+import sys
+import os
+import pysixtracklib as pyst
+import pysixtracklib_test as testlib
+
+from cobjects import CBuffer
+
+if __name__ == '__main__':
+    path_to_testdir = testlib.config.PATH_TO_TESTDATA_DIR
+    assert(path_to_testdir is not None)
+    assert(os.path.exists(path_to_testdir))
+    assert(os.path.isdir(path_to_testdir))
+
+    path_to_particle_data = os.path.join(
+        path_to_testdir, "beambeam", "particles_dump.bin")
+    assert(os.path.exists(path_to_particle_data))
+
+    path_to_beam_elements_data = os.path.join(
+        path_to_testdir, "beambeam", "beam_elements.bin")
+    assert(os.path.exists(path_to_beam_elements_data))
+
+    # -------------------------------------------------------------------------
+    eb = CBuffer.fromfile(path_to_beam_elements_data)
+    eb_data_begin  = eb.base
+    eb_data_size   = eb.size
+    eb_num_objects = eb.n_objects
+
+    pb = CBuffer.fromfile(path_to_particle_data)
+    assert( pb.n_objects > 0 )
+    particle_type_id = pb.get_object_typeid( 0 )
+
+    pb_data_begin  = pb.base
+    pb_data_size   = pb.size
+    pb_num_objects = pb.n_objects
+
+    # Testcase 1: only default parameters, no elem by elem output, no
+    # beam monitors
+
+    job = pyst.TrackJob( eb, pb )
+
+    assert( job.type_str() == 'cpu' )
+    assert( job.particles_buffer == pb )
+    assert( job.beam_elements_buffer == eb )
+    assert( not job.has_output_buffer() )
+    assert( job.output_buffer is None )
+    assert( not job.has_elem_by_elem_output() )
+    assert( not job.has_beam_monitor_output() )
+    assert( job.num_beam_monitors() == 0 )
+    assert( job.elem_by_elem_output_offset() == 0 )
+    assert( job.beam_monitor_output_offset() == 0 )
+
+    del job
+    job = None
+
+    assert( eb.base       == eb_data_begin )
+    assert( eb.size       == eb_data_size  )
+    assert( eb.n_objects  == eb_num_objects )
+
+    assert( pb.base       == pb_data_begin )
+    assert( pb.size       == pb_data_size )
+    assert( pb.n_objects  == pb_num_objects )
+
+    # -------------------------------------------------------------------------
+    # Testcase 2: only elem by elem output, no beam monitors
+
+    until_turn_elem_by_elem = 5
+
+    job = pyst.TrackJob( eb, pb, until_turn_elem_by_elem )
+
+    assert( job.type_str() == 'cpu' )
+    assert( job.particles_buffer == pb )
+    assert( job.beam_elements_buffer == eb )
+    assert( job.has_output_buffer() )
+    assert( job.output_buffer is not None )
+    assert( job.output_buffer.n_objects == 1 )
+
+    assert( job.has_elem_by_elem_output() )
+    assert( job.elem_by_elem_output_offset() < job.output_buffer.n_objects )
+    elem_by_elem_offset = job.elem_by_elem_output_offset()
+
+    assert( job.output_buffer.get_object_typeid( elem_by_elem_offset ) ==
+            particle_type_id )
+
+    assert( not job.has_beam_monitor_output() )
+    assert( job.num_beam_monitors() == 0 )
+    assert( job.elem_by_elem_output_offset() == 0 )
+    assert( job.beam_monitor_output_offset() >
+            job.elem_by_elem_output_offset() )
+
+    del job
+    job = None
+
+    assert( eb.base       == eb_data_begin )
+    assert( eb.size       == eb_data_size  )
+    assert( eb.n_objects  == eb_num_objects )
+
+    assert( pb.base       == pb_data_begin )
+    assert( pb.size       == pb_data_size )
+    assert( pb.n_objects  == pb_num_objects )
+
+
+    # -------------------------------------------------------------------------
+    # Testcase 3: only beam monitors, no elem by elem output
+
+    until_turn_elem_by_elem = 0
+    until_turn_turn_by_turn = 5
+    until_turn_output       = 100
+    skip_turns              = 10
+
+    num_beam_monitors = pyst.append_beam_monitors_to_lattice( eb,
+        until_turn_elem_by_elem, until_turn_turn_by_turn, until_turn_output,
+            skip_turns=skip_turns )
+
+    assert( num_beam_monitors == 2 )
+    assert( eb_num_objects + num_beam_monitors == eb.n_objects )
+
+    eb_num_objects = eb.n_objects
+    eb_data_begin  = eb.base
+    eb_data_size   = eb.size
+
+    job = pyst.TrackJob( eb, pb, until_turn_elem_by_elem )
+
+    assert( job.type_str() == 'cpu' )
+    assert( job.particles_buffer == pb )
+    assert( job.beam_elements_buffer == eb )
+    assert( job.has_output_buffer() )
+    assert( job.output_buffer is not None )
+    assert( job.output_buffer.n_objects == num_beam_monitors )
+
+    assert( not job.has_elem_by_elem_output() )
+    assert( job.elem_by_elem_output_offset() == 0 )
+    assert( job.beam_monitor_output_offset() == 0 )
+    beam_monitor_output_offset = job.beam_monitor_output_offset()
+
+    assert( job.output_buffer.get_object_typeid( beam_monitor_output_offset ) ==
+            particle_type_id )
+
+    assert( job.has_beam_monitor_output() )
+    assert( job.num_beam_monitors() == num_beam_monitors )
+
+    del job
+    job = None
+
+    assert( eb.base       == eb_data_begin )
+    assert( eb.size       == eb_data_size  )
+    assert( eb.n_objects  == eb_num_objects )
+
+    assert( pb.base       == pb_data_begin )
+    assert( pb.size       == pb_data_size )
+    assert( pb.n_objects  == pb_num_objects )
+
+    # -------------------------------------------------------------------------
+    # Testcase 4: elem by elem output + beam_monitors
+
+    until_turn_elem_by_elem = 2
+    until_turn_turn_by_turn = 5
+    until_turn_output       = 100
+    skip_turns              = 10
+
+    job = pyst.TrackJob( eb, pb, until_turn_elem_by_elem )
+
+    assert( job.type_str() == 'cpu' )
+    assert( job.particles_buffer == pb )
+    assert( job.beam_elements_buffer == eb )
+    assert( job.has_output_buffer() )
+    assert( job.output_buffer is not None )
+    assert( job.output_buffer.n_objects == ( num_beam_monitors + 1 ) )
+
+    assert( job.has_elem_by_elem_output() )
+    assert( job.has_beam_monitor_output() )
+
+    elem_by_elem_output_offset = job.elem_by_elem_output_offset()
+    beam_monitor_output_offset = job.beam_monitor_output_offset()
+    assert( elem_by_elem_output_offset == 0 )
+    assert( elem_by_elem_output_offset < beam_monitor_output_offset )
+    assert( beam_monitor_output_offset + num_beam_monitors <=
+            job.output_buffer.n_objects )
+
+    assert( job.output_buffer.get_object_typeid(
+            beam_monitor_output_offset ) == particle_type_id )
+
+    for ii in range( num_beam_monitors ):
+        jj = ii + beam_monitor_output_offset
+        assert( job.output_buffer.get_object_typeid( jj ) == particle_type_id )
+
+    assert( job.has_beam_monitor_output() )
+    assert( job.num_beam_monitors() == num_beam_monitors )
+
+    del job
+    job = None
+
+    assert( eb.base       == eb_data_begin )
+    assert( eb.size       == eb_data_size  )
+    assert( eb.n_objects  == eb_num_objects )
+
+    assert( pb.base       == pb_data_begin )
+    assert( pb.size       == pb_data_size )
+    assert( pb.n_objects  == pb_num_objects )
+
+    sys.exit( 0 )
+
+# end: tests/python/test_track_job_setup.py

--- a/tests/python/test_track_job_setup.py
+++ b/tests/python/test_track_job_setup.py
@@ -21,182 +21,184 @@ if __name__ == '__main__':
 
     # -------------------------------------------------------------------------
     eb = CBuffer.fromfile(path_to_beam_elements_data)
-    eb_data_begin  = eb.base
-    eb_data_size   = eb.size
+    eb_data_begin = eb.base
+    eb_data_size = eb.size
     eb_num_objects = eb.n_objects
 
     pb = CBuffer.fromfile(path_to_particle_data)
-    assert( pb.n_objects > 0 )
-    particle_type_id = pb.get_object_typeid( 0 )
+    assert(pb.n_objects > 0)
+    particle_type_id = pb.get_object_typeid(0)
 
-    pb_data_begin  = pb.base
-    pb_data_size   = pb.size
+    pb_data_begin = pb.base
+    pb_data_size = pb.size
     pb_num_objects = pb.n_objects
 
     # Testcase 1: only default parameters, no elem by elem output, no
     # beam monitors
 
-    job = pyst.TrackJob( eb, pb )
+    job = pyst.TrackJob(eb, pb)
 
-    assert( job.type_str() == 'cpu' )
-    assert( job.particles_buffer == pb )
-    assert( job.beam_elements_buffer == eb )
-    assert( not job.has_output_buffer() )
-    assert( job.output_buffer is None )
-    assert( not job.has_elem_by_elem_output() )
-    assert( not job.has_beam_monitor_output() )
-    assert( job.num_beam_monitors() == 0 )
-    assert( job.elem_by_elem_output_offset() == 0 )
-    assert( job.beam_monitor_output_offset() == 0 )
+    assert(job.type_str() == 'cpu')
+    assert(job.particles_buffer == pb)
+    assert(job.beam_elements_buffer == eb)
+    assert(not job.has_output_buffer())
+    assert(job.output_buffer is None)
+    assert(not job.has_elem_by_elem_output())
+    assert(not job.has_beam_monitor_output())
+    assert(job.num_beam_monitors() == 0)
+    assert(job.elem_by_elem_output_offset() == 0)
+    assert(job.beam_monitor_output_offset() == 0)
 
     del job
     job = None
 
-    assert( eb.base       == eb_data_begin )
-    assert( eb.size       == eb_data_size  )
-    assert( eb.n_objects  == eb_num_objects )
+    assert(eb.base == eb_data_begin)
+    assert(eb.size == eb_data_size)
+    assert(eb.n_objects == eb_num_objects)
 
-    assert( pb.base       == pb_data_begin )
-    assert( pb.size       == pb_data_size )
-    assert( pb.n_objects  == pb_num_objects )
+    assert(pb.base == pb_data_begin)
+    assert(pb.size == pb_data_size)
+    assert(pb.n_objects == pb_num_objects)
 
     # -------------------------------------------------------------------------
     # Testcase 2: only elem by elem output, no beam monitors
 
     until_turn_elem_by_elem = 5
 
-    job = pyst.TrackJob( eb, pb, until_turn_elem_by_elem )
+    job = pyst.TrackJob(eb, pb, until_turn_elem_by_elem)
 
-    assert( job.type_str() == 'cpu' )
-    assert( job.particles_buffer == pb )
-    assert( job.beam_elements_buffer == eb )
-    assert( job.has_output_buffer() )
-    assert( job.output_buffer is not None )
-    assert( job.output_buffer.n_objects == 1 )
+    assert(job.type_str() == 'cpu')
+    assert(job.particles_buffer == pb)
+    assert(job.beam_elements_buffer == eb)
+    assert(job.has_output_buffer())
+    assert(job.output_buffer is not None)
+    assert(job.output_buffer.n_objects == 1)
 
-    assert( job.has_elem_by_elem_output() )
-    assert( job.elem_by_elem_output_offset() < job.output_buffer.n_objects )
+    assert(job.has_elem_by_elem_output())
+    assert(job.elem_by_elem_output_offset() < job.output_buffer.n_objects)
     elem_by_elem_offset = job.elem_by_elem_output_offset()
 
-    assert( job.output_buffer.get_object_typeid( elem_by_elem_offset ) ==
-            particle_type_id )
+    assert(job.output_buffer.get_object_typeid(elem_by_elem_offset) ==
+           particle_type_id)
 
-    assert( not job.has_beam_monitor_output() )
-    assert( job.num_beam_monitors() == 0 )
-    assert( job.elem_by_elem_output_offset() == 0 )
-    assert( job.beam_monitor_output_offset() >
-            job.elem_by_elem_output_offset() )
+    assert(not job.has_beam_monitor_output())
+    assert(job.num_beam_monitors() == 0)
+    assert(job.elem_by_elem_output_offset() == 0)
+    assert(job.beam_monitor_output_offset() >
+           job.elem_by_elem_output_offset())
 
     del job
     job = None
 
-    assert( eb.base       == eb_data_begin )
-    assert( eb.size       == eb_data_size  )
-    assert( eb.n_objects  == eb_num_objects )
+    assert(eb.base == eb_data_begin)
+    assert(eb.size == eb_data_size)
+    assert(eb.n_objects == eb_num_objects)
 
-    assert( pb.base       == pb_data_begin )
-    assert( pb.size       == pb_data_size )
-    assert( pb.n_objects  == pb_num_objects )
-
+    assert(pb.base == pb_data_begin)
+    assert(pb.size == pb_data_size)
+    assert(pb.n_objects == pb_num_objects)
 
     # -------------------------------------------------------------------------
     # Testcase 3: only beam monitors, no elem by elem output
 
     until_turn_elem_by_elem = 0
     until_turn_turn_by_turn = 5
-    until_turn_output       = 100
-    skip_turns              = 10
+    until_turn_output = 100
+    skip_turns = 10
 
-    num_beam_monitors = pyst.append_beam_monitors_to_lattice( eb,
-        until_turn_elem_by_elem, until_turn_turn_by_turn, until_turn_output,
-            skip_turns=skip_turns )
+    num_beam_monitors = pyst.append_beam_monitors_to_lattice(
+        eb,
+        until_turn_elem_by_elem,
+        until_turn_turn_by_turn,
+        until_turn_output,
+        skip_turns=skip_turns)
 
-    assert( num_beam_monitors == 2 )
-    assert( eb_num_objects + num_beam_monitors == eb.n_objects )
+    assert(num_beam_monitors == 2)
+    assert(eb_num_objects + num_beam_monitors == eb.n_objects)
 
     eb_num_objects = eb.n_objects
-    eb_data_begin  = eb.base
-    eb_data_size   = eb.size
+    eb_data_begin = eb.base
+    eb_data_size = eb.size
 
-    job = pyst.TrackJob( eb, pb, until_turn_elem_by_elem )
+    job = pyst.TrackJob(eb, pb, until_turn_elem_by_elem)
 
-    assert( job.type_str() == 'cpu' )
-    assert( job.particles_buffer == pb )
-    assert( job.beam_elements_buffer == eb )
-    assert( job.has_output_buffer() )
-    assert( job.output_buffer is not None )
-    assert( job.output_buffer.n_objects == num_beam_monitors )
+    assert(job.type_str() == 'cpu')
+    assert(job.particles_buffer == pb)
+    assert(job.beam_elements_buffer == eb)
+    assert(job.has_output_buffer())
+    assert(job.output_buffer is not None)
+    assert(job.output_buffer.n_objects == num_beam_monitors)
 
-    assert( not job.has_elem_by_elem_output() )
-    assert( job.elem_by_elem_output_offset() == 0 )
-    assert( job.beam_monitor_output_offset() == 0 )
+    assert(not job.has_elem_by_elem_output())
+    assert(job.elem_by_elem_output_offset() == 0)
+    assert(job.beam_monitor_output_offset() == 0)
     beam_monitor_output_offset = job.beam_monitor_output_offset()
 
-    assert( job.output_buffer.get_object_typeid( beam_monitor_output_offset ) ==
-            particle_type_id )
+    assert(job.output_buffer.get_object_typeid(beam_monitor_output_offset) ==
+           particle_type_id)
 
-    assert( job.has_beam_monitor_output() )
-    assert( job.num_beam_monitors() == num_beam_monitors )
+    assert(job.has_beam_monitor_output())
+    assert(job.num_beam_monitors() == num_beam_monitors)
 
     del job
     job = None
 
-    assert( eb.base       == eb_data_begin )
-    assert( eb.size       == eb_data_size  )
-    assert( eb.n_objects  == eb_num_objects )
+    assert(eb.base == eb_data_begin)
+    assert(eb.size == eb_data_size)
+    assert(eb.n_objects == eb_num_objects)
 
-    assert( pb.base       == pb_data_begin )
-    assert( pb.size       == pb_data_size )
-    assert( pb.n_objects  == pb_num_objects )
+    assert(pb.base == pb_data_begin)
+    assert(pb.size == pb_data_size)
+    assert(pb.n_objects == pb_num_objects)
 
     # -------------------------------------------------------------------------
     # Testcase 4: elem by elem output + beam_monitors
 
     until_turn_elem_by_elem = 2
     until_turn_turn_by_turn = 5
-    until_turn_output       = 100
-    skip_turns              = 10
+    until_turn_output = 100
+    skip_turns = 10
 
-    job = pyst.TrackJob( eb, pb, until_turn_elem_by_elem )
+    job = pyst.TrackJob(eb, pb, until_turn_elem_by_elem)
 
-    assert( job.type_str() == 'cpu' )
-    assert( job.particles_buffer == pb )
-    assert( job.beam_elements_buffer == eb )
-    assert( job.has_output_buffer() )
-    assert( job.output_buffer is not None )
-    assert( job.output_buffer.n_objects == ( num_beam_monitors + 1 ) )
+    assert(job.type_str() == 'cpu')
+    assert(job.particles_buffer == pb)
+    assert(job.beam_elements_buffer == eb)
+    assert(job.has_output_buffer())
+    assert(job.output_buffer is not None)
+    assert(job.output_buffer.n_objects == (num_beam_monitors + 1))
 
-    assert( job.has_elem_by_elem_output() )
-    assert( job.has_beam_monitor_output() )
+    assert(job.has_elem_by_elem_output())
+    assert(job.has_beam_monitor_output())
 
     elem_by_elem_output_offset = job.elem_by_elem_output_offset()
     beam_monitor_output_offset = job.beam_monitor_output_offset()
-    assert( elem_by_elem_output_offset == 0 )
-    assert( elem_by_elem_output_offset < beam_monitor_output_offset )
-    assert( beam_monitor_output_offset + num_beam_monitors <=
-            job.output_buffer.n_objects )
+    assert(elem_by_elem_output_offset == 0)
+    assert(elem_by_elem_output_offset < beam_monitor_output_offset)
+    assert(beam_monitor_output_offset + num_beam_monitors <=
+           job.output_buffer.n_objects)
 
-    assert( job.output_buffer.get_object_typeid(
-            beam_monitor_output_offset ) == particle_type_id )
+    assert(job.output_buffer.get_object_typeid(
+        beam_monitor_output_offset) == particle_type_id)
 
-    for ii in range( num_beam_monitors ):
+    for ii in range(num_beam_monitors):
         jj = ii + beam_monitor_output_offset
-        assert( job.output_buffer.get_object_typeid( jj ) == particle_type_id )
+        assert(job.output_buffer.get_object_typeid(jj) == particle_type_id)
 
-    assert( job.has_beam_monitor_output() )
-    assert( job.num_beam_monitors() == num_beam_monitors )
+    assert(job.has_beam_monitor_output())
+    assert(job.num_beam_monitors() == num_beam_monitors)
 
     del job
     job = None
 
-    assert( eb.base       == eb_data_begin )
-    assert( eb.size       == eb_data_size  )
-    assert( eb.n_objects  == eb_num_objects )
+    assert(eb.base == eb_data_begin)
+    assert(eb.size == eb_data_size)
+    assert(eb.n_objects == eb_num_objects)
 
-    assert( pb.base       == pb_data_begin )
-    assert( pb.size       == pb_data_size )
-    assert( pb.n_objects  == pb_num_objects )
+    assert(pb.base == pb_data_begin)
+    assert(pb.size == pb_data_size)
+    assert(pb.n_objects == pb_num_objects)
 
-    sys.exit( 0 )
+    sys.exit(0)
 
 # end: tests/python/test_track_job_setup.py

--- a/tests/sixtracklib/common/CMakeLists.txt
+++ b/tests/sixtracklib/common/CMakeLists.txt
@@ -198,6 +198,20 @@ if( GTEST_FOUND )
     add_test( C99_CommonTrackTests test_track_common_c99 )
 
     # ==========================================================================
+    # test_track_job_common_c99:
+
+    add_executable( test_track_job_common_c99 test_track_job_c99.cpp )
+    set( UNIT_TEST_TARGETS ${UNIT_TEST_TARGETS} test_track_job_common_c99 )
+    add_test( C99_CommonTrackJobTests, test_track_job_common_c99 )
+
+    # --------------------------------------------------------------------------
+    # test_track_job_common_cxx:
+
+    add_executable( test_track_job_common_cxx test_track_job_cxx.cpp )
+    set( UNIT_TEST_TARGETS ${UNIT_TEST_TARGETS} test_track_job_common_cxx )
+    add_test( CXX_CommonTrackJobTests, test_track_job_common_cxx )
+
+    # ==========================================================================
     # test_track_job_cpu_common_c99:
 
     add_executable( test_track_job_cpu_common_c99 test_track_job_cpu_c99.cpp )

--- a/tests/sixtracklib/common/test_track_job_c99.cpp
+++ b/tests/sixtracklib/common/test_track_job_c99.cpp
@@ -1,0 +1,62 @@
+#include "sixtracklib/common/track_job.h"
+
+#include <cstddef>
+#include <cstdint>
+#include <cstdlib>
+#include <cstring>
+#include <cmath>
+#include <string>
+#include <utility>
+
+#include <gtest/gtest.h>
+
+#include "sixtracklib/common/definitions.h"
+#include "sixtracklib/common/generated/path.h"
+#include "sixtracklib/common/buffer.h"
+
+#include "sixtracklib/testlib/testdata/testdata_files.h"
+
+TEST( C99_TrackJobTests, DeviceIdAndConfigStrTests )
+{
+    using buf_size_t = ::NS(buffer_size_t);
+    std::string conf_str( "" );
+
+    ::NS(buffer_size_t) const max_out_str_len = 32u;
+    char device_id_str[ 32 ];
+    std::memset( &device_id_str[ 0 ], ( int )'\0', max_out_str_len );
+
+    int ret = ::NS(TrackJob_extract_device_id_str)(
+        conf_str.c_str(), &device_id_str[ 0 ], max_out_str_len );
+
+    ASSERT_TRUE( ret == 0 );
+    ASSERT_TRUE( std::strlen( &device_id_str[ 0 ] ) == buf_size_t{ 0 } );
+
+    conf_str = "0.0";
+    std::memset( &device_id_str[ 0 ], ( int )'\0', max_out_str_len );
+
+    ret = ::NS(TrackJob_extract_device_id_str)(
+        conf_str.c_str(), &device_id_str[ 0 ], max_out_str_len );
+
+    ASSERT_TRUE( ret == 0 );
+    ASSERT_TRUE( std::strcmp( &device_id_str[ 0 ], "0.0" ) == 0 );
+
+    conf_str = "  0.0  ";
+    std::memset( &device_id_str[ 0 ], ( int )'\0', max_out_str_len );
+
+    ret = ::NS(TrackJob_extract_device_id_str)(
+        conf_str.c_str(), &device_id_str[ 0 ], max_out_str_len );
+
+    ASSERT_TRUE( ret == 0 );
+    ASSERT_TRUE( std::strcmp( &device_id_str[ 0 ], "0.0" ) == 0 );
+
+//     conf_str = "0.0;a=b;#this is a comment";
+//     std::memset( &device_id_str[ 0 ], ( int )'\0', max_out_str_len );
+//
+//     ret = ::NS(TrackJob_extract_device_id_str)(
+//         conf_str.c_str(), &device_id_str[ 0 ], max_out_str_len );
+//
+//     ASSERT_TRUE( ret == 0 );
+//     ASSERT_TRUE( std::strcmp( &device_id_str[ 0 ], "0.0" ) == 0 );
+}
+
+/* end: tests/sixtracklib/common/test_track_job_c99.cpp */

--- a/tests/sixtracklib/common/test_track_job_cxx.cpp
+++ b/tests/sixtracklib/common/test_track_job_cxx.cpp
@@ -1,0 +1,39 @@
+#include "sixtracklib/common/track_job.h"
+
+#include <cstddef>
+#include <cstdint>
+#include <cstdlib>
+#include <cstring>
+#include <cmath>
+#include <string>
+#include <utility>
+
+#include <gtest/gtest.h>
+
+#include "sixtracklib/common/definitions.h"
+
+TEST( CXX_TrackJobTests, DeviceIdAndConfigStrTests )
+{
+    namespace st = SIXTRL_CXX_NAMESPACE;
+
+    std::string conf_str( "" );
+    std::string device_id_str = st::TrackJob_extract_device_id_str(conf_str );
+    ASSERT_TRUE( device_id_str.empty() );
+
+    conf_str = "0.0";
+    device_id_str = st::TrackJob_extract_device_id_str( conf_str );
+
+    ASSERT_TRUE( device_id_str.compare( "0.0" ) == 0 );
+
+    conf_str = "  0.0  ";
+    device_id_str = st::TrackJob_extract_device_id_str( conf_str );
+
+    ASSERT_TRUE( device_id_str.compare( "0.0" ) == 0 );
+
+//     conf_str = "0.0;a=b;#this is a comment";
+//     device_id_str = st::TrackJob_extract_device_id_str( conf_str );
+//
+//     ASSERT_TRUE( device_id_str.compare( "0.0" ) == 0 );
+}
+
+/* end: tests/sixtracklib/common/test_track_job_cxx.cpp */


### PR DESCRIPTION
- Updates the python TrackJob implementation to allow scenarios with no output_buffer. For consistency, the C99 API to handle the different scenarios and corner cases is re-used in Python

- Adds a unit-test tests/python/test_track_job_setup.py to verify that the initialization of the TrackJob is consistent with all the different corner cases (especially regarding the output_buffer)

- The init function of the TrackJob now raises Exceptions close to the point of error rather than 
trying to perform an atomic construction of the object with a summary exception at the end.
__Warning__: Do not attempt to catch an exception thrown during construction of a TrackJob and then continueing to use the instance! This will result in undefined behaviour!

- Updates all python related unit-tests to reflect the new API / signatures for the TrackJob

- Expand the track_job_simple.py example a little to demonstrate the track_line usage
__Note__: the track_line method currently does not perform anything meaningful for OpenCl and has been tested only very superficially for the CPU backend. Since the API is in my view ready for feedback and could stay like this, it is already included in the examples. Any feedback would be appreciated

- Contains a rewritten version of the full/more complete track_job.py example to also reflect the latest API. This example should be more or less functionally equivalent to the track_io.c example for C99

- Expose additional functions from C99 to python (mostly related to the handling of the output buffer cases during TrackJob construction)

- Cosmetic changes due to application of autopep8 on (hopefully, we shall see :-) ) all python related files