### PR TITLE
line_tracking, improvements to collect, cosmetic changes

### DIFF
--- a/examples/python/cuda_particle_addr.py
+++ b/examples/python/cuda_particle_addr.py
@@ -16,53 +16,53 @@ if __name__ == '__main__':
     num_particles = 42
     partset = pyst.ParticlesSet()
     particles = partset.Particles(num_particles=num_particles)
-    pbuffer = st.st_Buffer_new_mapped_on_cbuffer( pset.cbuffer )
+    pbuffer = st.st_Buffer_new_mapped_on_cbuffer(pset.cbuffer)
 
     ctx = st.st_CudaContext_create()
-    particles_arg = st.st_CudaArgument_new( ctx )
+    particles_arg = st.st_CudaArgument_new(ctx)
 
-    st.st_CudaArgument_send_buffer( particles_arg, pbuffer )
+    st.st_CudaArgument_send_buffer(particles_arg, pbuffer)
 
     particles_addr = st.st_ParticlesAddr()
-    sizeof_particles_addr = ct.sizeof( st.st_ParticlesAddr )
-    sizeof_particles_addr = ct.c_uint64( sizeof_particles_addr )
+    sizeof_particles_addr = ct.sizeof(st.st_ParticlesAddr)
+    sizeof_particles_addr = ct.c_uint64(sizeof_particles_addr)
 
-    ptr_particles_addr = st.st_ParticlesAddr_preset( ct.byref( particles_addr )  )
-    particles_addr_arg = st.st_CudaArgument_new( ctx )
+    ptr_particles_addr = st.st_ParticlesAddr_preset(ct.byref(particles_addr))
+    particles_addr_arg = st.st_CudaArgument_new(ctx)
     st.st_CudaArgument_send_memory(
-        particles_addr_arg, ptr_particles_addr, sizeof_particles_addr )
+        particles_addr_arg, ptr_particles_addr, sizeof_particles_addr)
 
     st.st_Particles_extract_addresses_cuda(
-        st.st_CudaArgument_get_arg_buffer( particles_addr_arg ),
-        st.st_CudaArgument_get_arg_buffer( particles_arg ) )
+        st.st_CudaArgument_get_arg_buffer(particles_addr_arg),
+        st.st_CudaArgument_get_arg_buffer(particles_arg))
 
     st.st_CudaArgument_receive_memory(
-        particles_addr_arg, ptr_particles_addr, sizeof_particles_addr )
+        particles_addr_arg, ptr_particles_addr, sizeof_particles_addr)
 
-    print( "Particle structure data on the device:" )
-    print( "num_particles = {0:8d}".format( particles_addr.num_particles ) )
-    print( "x     begin at = {0:16x}".format( particles_addr.x ) )
-    print( "y     begin at = {0:16x}".format( particles_addr.y ) )
-    print( "px    begin at = {0:16x}".format( particles_addr.px ) )
-    print( "py    begin at = {0:16x}".format( particles_addr.py ) )
-    print( "zeta  begin at = {0:16x}".format( particles_addr.zeta ) )
-    print( "delta begin at = {0:16x}".format( particles_addr.delta ) )
+    print("Particle structure data on the device:")
+    print("num_particles = {0:8d}".format(particles_addr.num_particles))
+    print("x     begin at = {0:16x}".format(particles_addr.x))
+    print("y     begin at = {0:16x}".format(particles_addr.y))
+    print("px    begin at = {0:16x}".format(particles_addr.px))
+    print("py    begin at = {0:16x}".format(particles_addr.py))
+    print("zeta  begin at = {0:16x}".format(particles_addr.zeta))
+    print("delta begin at = {0:16x}".format(particles_addr.delta))
 
     x = pycuda.gpuarray.GPUArray(
-            particles_addr.num_particles, float, gpudata=particles_addr.x )
+        particles_addr.num_particles, float, gpudata=particles_addr.x)
 
-    x = np.array( [ float( ii ) for ii in range( particles_addr.num_particles ) ] )
+    x = np.array([float(ii) for ii in range(particles_addr.num_particles)])
 
-    st.st_CudaArgument_receive_buffer( particles_arg, pbuffer )
+    st.st_CudaArgument_receive_buffer(particles_arg, pbuffer)
 
-    cmp_particles = pset.cbuffer.get_object( 0, pyst.Particles )
+    cmp_particles = pset.cbuffer.get_object(0, pyst.Particles)
 
-    assert( pyst.compareParticlesDifference(
-            cmp_particles, particles, abs_treshold=2e-14 ) == 0 )
+    assert(pyst.compareParticlesDifference(
+        cmp_particles, particles, abs_treshold=2e-14) == 0)
 
-    st.st_CudaContext_delete( ctx )
-    st.st_CudaArgument_delete( particles_arg )
-    st.st_CudaArgument_delete( particles_addr_arg )
-    st.st_Buffer_delete( pbuffer )
+    st.st_CudaContext_delete(ctx)
+    st.st_CudaArgument_delete(particles_arg)
+    st.st_CudaArgument_delete(particles_addr_arg)
+    st.st_Buffer_delete(pbuffer)
 
-    sys.exit( 0 )
+    sys.exit(0)

--- a/examples/python/track_job_short.py
+++ b/examples/python/track_job_short.py
@@ -9,8 +9,8 @@ elements = pyst.Elements()
 elements.Drift(length=1.2)
 elements.Multipole(knl=[0, 0.001])
 
-particles = pyst.Particles.from_ref(num_particles=10,p0c=1e9)
-particles.px += np.linspace(0,1e-2,10)
+particles = pyst.Particles.from_ref(num_particles=10, p0c=1e9)
+particles.px += np.linspace(0, 1e-2, 10)
 
 job = pyst.TrackJob(elements, particles)
 status = job.track(1)

--- a/python/pysixtracklib/beam_elements.py
+++ b/python/pysixtracklib/beam_elements.py
@@ -10,6 +10,7 @@ from pysixtrack import track as pysixelem
 
 from .mad_helper import madseq_to_line
 
+
 class Drift(CObject):
     _typeid = 2
     length = CField(0, 'real', default=0.0, alignment=8)
@@ -354,7 +355,7 @@ class Elements(object):
         for name, cls in self.element_types.items():
             setattr(self, name, self._mk_fun(self.cbuffer, cls))
             self.cbuffer.typeids[cls._typeid] = cls
-        self._builder=self.gen_builder()
+        self._builder = self.gen_builder()
 
     def gen_builder(self):
         out = {}
@@ -371,11 +372,11 @@ class Elements(object):
 
     @classmethod
     def from_mad(cls, seq):
-        line=madseq_to_line(seq)
+        line = madseq_to_line(seq)
         return cls.fromline(line)
 
-    #@classmethod
-    #def from_mad2(cls, seq):
+    # @classmethod
+    # def from_mad2(cls, seq):
     #    self=cls()
     #    list(madseq_to_line(seq,self._builder))
     #    return self

--- a/python/pysixtracklib/mad_helper.py
+++ b/python/pysixtracklib/mad_helper.py
@@ -10,39 +10,46 @@ classes = dict(
     Line=namedtuple('Line', 'elems'),
 )
 
-def dispatch(el,classes):
-    Drift=classes['Drift']
-    Multipole=classes['Multipole']
-    Cavity=classes['Cavity']
 
-    key=el.base_type.name
-    if key=='multipole':
-        el=Multipole(knl=el.knl,ksl=el.ksl,hxl=el.knl[0],hyl=0,length=el.lrad)
+def dispatch(el, classes):
+    Drift = classes['Drift']
+    Multipole = classes['Multipole']
+    Cavity = classes['Cavity']
+
+    key = el.base_type.name
+    if key == 'multipole':
+        el = Multipole(
+            knl=el.knl,
+            ksl=el.ksl,
+            hxl=el.knl[0],
+            hyl=0,
+            length=el.lrad)
     elif key in ['marker', 'hmonitor', 'vmonitor', 'instrument',
                  'monitor', 'rcollimator']:
-        el=Drift(length=0)
+        el = Drift(length=0)
     elif key == 'hkicker':
-        el=Multipole(knl=[-el.kick], ksl=[],
-                           length=el.lrad, hxl=0, hyl=0)
+        el = Multipole(knl=[-el.kick], ksl=[],
+                       length=el.lrad, hxl=0, hyl=0)
     elif key == 'vkicker':
-        el=Multipole(knl=[], ksl=[el.kick],
-                     length=el.lrad, hxl=0, hyl=0)
+        el = Multipole(knl=[], ksl=[el.kick],
+                       length=el.lrad, hxl=0, hyl=0)
     elif key == 'rfcavity':
-        el=Cavity(voltage=el.volt*1e6,
-                  frequency=el.freq*1e6, lag=el.lag*360)
+        el = Cavity(voltage=el.volt * 1e6,
+                    frequency=el.freq * 1e6, lag=el.lag * 360)
     return el
 
+
 def madseq_to_line(seq, convert=classes):
-    Drift=convert['Drift']
+    Drift = convert['Drift']
     oldpos = 0
-    poss=seq.element_positions()
-    names=seq.element_names()
-    for name,pos,el in zip(names,poss, seq.elements):
+    poss = seq.element_positions()
+    names = seq.element_names()
+    for name, pos, el in zip(names, poss, seq.elements):
         if el.length > 0:
             raise ValueError(f"Seq {seq} contails {el} with length>0")
-        length = pos-oldpos
+        length = pos - oldpos
         if length > 0:
             yield "drift", "Drift", Drift(length)
-        el=dispatch(el,convert)
-        oldpos=pos
-        yield name,el.__class__.__name__,el
+        el = dispatch(el, convert)
+        oldpos = pos
+        yield name, el.__class__.__name__, el

--- a/python/pysixtracklib/particles.py
+++ b/python/pysixtracklib/particles.py
@@ -3,19 +3,19 @@ import numpy as np
 
 
 class Particles(CObject):
-    pmass= 938.2720813e6
+    pmass = 938.2720813e6
 
     def _set_p0c(self):
-        energy0=np.sqrt(self.p0c**2+self.mass0**2)
-        self.beta0=self.p0c/energy0
+        energy0 = np.sqrt(self.p0c**2 + self.mass0**2)
+        self.beta0 = self.p0c / energy0
         self.gamma0 = energy0 / self.mass0
 
     def _set_delta(self):
-        rep=np.sqrt(self.delta**2+2*self.delta+1/self.beta0**2)
-        irpp=1+self.delta
-        self.rpp=1/irpp
-        beta=irpp/rep
-        self.rvv=beta/self.beta0
+        rep = np.sqrt(self.delta**2 + 2 * self.delta + 1 / self.beta0**2)
+        irpp = 1 + self.delta
+        self.rpp = 1 / irpp
+        beta = irpp / rep
+        self.rvv = beta / self.beta0
 
     _typeid = 1
     num_particles = CField(0, 'int64', const=True)
@@ -63,8 +63,8 @@ class Particles(CObject):
                    default=1, pointer=True, alignment=8)
 
     @classmethod
-    def from_ref(cls,num_particles=1,mass0=938272081.3,
-                     p0c=1e9, q0=1,**kwargs):
+    def from_ref(cls, num_particles=1, mass0=938272081.3,
+                 p0c=1e9, q0=1, **kwargs):
         return cls(num_particles=num_particles,
                    particle_id=np.arange(num_particles),
                    ).set_reference()

--- a/python/pysixtracklib/stcommon.py
+++ b/python/pysixtracklib/stcommon.py
@@ -110,8 +110,9 @@ class st_Particles(ct.Structure):
                 ("at_element", st_int64_p), ("at_turn", st_int64_p),
                 ("state", st_int64_p)]
 
-class st_ParticlesAddr( ct.Structure ):
-    _fields_ = [("num_particles", ct.c_int64),("q0", ct.c_uint64),
+
+class st_ParticlesAddr(ct.Structure):
+    _fields_ = [("num_particles", ct.c_int64), ("q0", ct.c_uint64),
                 ("mass0", ct.c_uint64), ("beta0", ct.c_uint64),
                 ("gamma0", ct.c_uint64), ("p0C", ct.c_uint64),
                 ("s", ct.c_uint64), ("x", ct.c_uint64), ("y", ct.c_uint64),
@@ -122,11 +123,12 @@ class st_ParticlesAddr( ct.Structure ):
                 ("at_element", ct.c_uint64), ("at_turn", ct.c_uint64),
                 ("state", ct.c_uint64)]
 
+
 st_Particles_p = ct.POINTER(st_Particles)
 st_NullParticles = ct.cast(0, st_Particles_p)
 
-st_ParticlesAddr_p = ct.POINTER( st_ParticlesAddr )
-st_NullParticlesAddr = ct.cast( 0, st_ParticlesAddr_p )
+st_ParticlesAddr_p = ct.POINTER(st_ParticlesAddr)
+st_NullParticlesAddr = ct.cast(0, st_ParticlesAddr_p)
 
 
 def st_Particles_cbuffer_get_particles(cbuffer, obj_index):
@@ -245,8 +247,8 @@ st_Particles_add_copy.restype = st_Particles_p
 st_Particles_add_copy.argtypes = [st_Buffer_p, st_Particles_p]
 
 st_ParticlesAddr_preset = sixtracklib.st_ParticlesAddr_preset
-st_ParticlesAddr_preset.argtypes = [ st_ParticlesAddr_p ]
-st_ParticlesAddr_preset.restype  = st_ParticlesAddr_p
+st_ParticlesAddr_preset.argtypes = [st_ParticlesAddr_p]
+st_ParticlesAddr_preset.restype = st_ParticlesAddr_p
 
 # -----------------------------------------------------------------------------
 # BeamMonitor objects
@@ -548,108 +550,109 @@ st_TrackJob_get_beam_monitor_output_buffer_offset.restype = ct.c_uint64
 # -----------------------------------------------------------------------------
 # Cuda-Context methods
 
-if SIXTRACKLIB_MODULES.get( 'cuda', False ):
+if SIXTRACKLIB_MODULES.get('cuda', False):
 
-    st_CudaContext_p    = ct.c_void_p
-    st_NullCudaContext  = ct.cast( 0, st_CudaContext_p )
+    st_CudaContext_p = ct.c_void_p
+    st_NullCudaContext = ct.cast(0, st_CudaContext_p)
 
-    st_CudaArgument_p   = ct.c_void_p
-    st_NullCudaArgument = ct.cast( 0, st_CudaArgument_p )
+    st_CudaArgument_p = ct.c_void_p
+    st_NullCudaArgument = ct.cast(0, st_CudaArgument_p)
 
     st_CudaContext_create = sixtracklib.st_CudaContext_create
     st_CudaContext_create.argtypes = None
     st_CudaContext_create.restype = st_CudaContext_p
 
     st_CudaContext_delete = sixtracklib.st_CudaContext_delete
-    st_CudaContext_delete.argtypes = [ st_CudaContext_p ]
-    st_CudaContext_delete.restype  = None
+    st_CudaContext_delete.argtypes = [st_CudaContext_p]
+    st_CudaContext_delete.restype = None
 
     st_CudaArgument_new = sixtracklib.st_CudaArgument_new
-    st_CudaArgument_new.argtypes = [ st_CudaContext_p ]
-    st_CudaArgument_new.restype  = st_CudaArgument_p
+    st_CudaArgument_new.argtypes = [st_CudaContext_p]
+    st_CudaArgument_new.restype = st_CudaArgument_p
 
     st_CudaArgument_new_from_buffer = \
         sixtracklib.st_CudaArgument_new_from_buffer
     st_CudaArgument_new_from_buffer.restype = st_CudaArgument_p
-    st_CudaArgument_new_from_buffer.argtypes = [ st_Buffer_p, st_CudaContext_p ]
+    st_CudaArgument_new_from_buffer.argtypes = [st_Buffer_p, st_CudaContext_p]
 
     st_CudaArgument_new_from_size = sixtracklib.st_CudaArgument_new_from_size
     st_CudaArgument_new_from_size.restype = st_CudaArgument_p
-    st_CudaArgument_new_from_size.argtypes = [ ct.c_uint64, st_CudaContext_p ]
+    st_CudaArgument_new_from_size.argtypes = [ct.c_uint64, st_CudaContext_p]
 
-    st_CudaArgument_new_from_memory = sixtracklib.st_CudaArgument_new_from_memory
+    st_CudaArgument_new_from_memory = \
+        sixtracklib.st_CudaArgument_new_from_memory
     st_CudaArgument_new_from_memory.restype = st_CudaArgument_p
     st_CudaArgument_new_from_memory.argtypes = [
-        ct.c_void_p, ct.c_uint64, st_CudaContext_p ]
+        ct.c_void_p, ct.c_uint64, st_CudaContext_p]
 
     st_CudaArgument_delete = sixtracklib.st_CudaArgument_delete
     st_CudaArgument_delete.restype = None
-    st_CudaArgument_delete.argtypes = [ st_CudaArgument_p ]
+    st_CudaArgument_delete.argtypes = [st_CudaArgument_p]
 
     st_CudaArgument_send_buffer = sixtracklib.st_CudaArgument_send_buffer
     st_CudaArgument_send_buffer.restype = ct.c_bool
-    st_CudaArgument_send_buffer.argtypes = [ st_CudaArgument_p, st_Buffer_p ]
+    st_CudaArgument_send_buffer.argtypes = [st_CudaArgument_p, st_Buffer_p]
 
     st_CudaArgument_send_memory = sixtracklib.st_CudaArgument_send_memory
     st_CudaArgument_send_memory.restype = ct.c_bool
     st_CudaArgument_send_memory.argtypes = [
-            st_CudaArgument_p, ct.c_void_p, ct.c_uint64 ]
+        st_CudaArgument_p, ct.c_void_p, ct.c_uint64]
 
     st_CudaArgument_receive_buffer = sixtracklib.st_CudaArgument_receive_buffer
     st_CudaArgument_receive_buffer.restype = ct.c_bool
-    st_CudaArgument_receive_buffer.argtypes = [ st_CudaArgument_p, st_Buffer_p ]
+    st_CudaArgument_receive_buffer.argtypes = [st_CudaArgument_p, st_Buffer_p]
 
     st_CudaArgument_receive_memory = sixtracklib.st_CudaArgument_receive_memory
     st_CudaArgument_receive_memory.restype = ct.c_bool
     st_CudaArgument_receive_memory.argtypes = [
-            st_CudaArgument_p, ct.c_void_p, ct.c_uint64 ]
+        st_CudaArgument_p, ct.c_void_p, ct.c_uint64]
 
     st_CudaArgument_get_arg_buffer = \
         sixtracklib.st_CudaArgument_get_cuda_arg_buffer
-    st_CudaArgument_get_arg_buffer.argtypes = [ st_CudaArgument_p ]
+    st_CudaArgument_get_arg_buffer.argtypes = [st_CudaArgument_p]
     st_CudaArgument_get_arg_buffer.restype = ct.c_void_p
 
     st_CudaArgument_uses_cobjects_buffer = \
         sixtracklib.st_CudaArgument_uses_cobjects_buffer
     st_CudaArgument_uses_cobjects_buffer.restype = ct.c_bool
-    st_CudaArgument_uses_cobjects_buffer.argtypes = [ st_CudaArgument_p ]
+    st_CudaArgument_uses_cobjects_buffer.argtypes = [st_CudaArgument_p]
 
     st_CudaArgument_get_cobjects_buffer =  \
         sixtracklib.st_CudaArgument_get_cobjects_buffer
     st_CudaArgument_get_cobjects_buffer.restype = st_Buffer_p
-    st_CudaArgument_get_cobjects_buffer.argtypes = [ st_CudaArgument_p ]
+    st_CudaArgument_get_cobjects_buffer.argtypes = [st_CudaArgument_p]
 
     st_CudaArgument_uses_raw_argument = \
         sixtracklib.st_CudaArgument_uses_raw_argument
     st_CudaArgument_uses_raw_argument.restype = ct.c_bool
-    st_CudaArgument_uses_raw_argument.argtypes = [ st_CudaArgument_p ]
+    st_CudaArgument_uses_raw_argument.argtypes = [st_CudaArgument_p]
 
     st_CudaArgument_get_ptr_raw_argument = \
         sixtracklib.st_CudaArgument_get_ptr_raw_argument
     st_CudaArgument_get_ptr_raw_argument.restype = ct.c_void_p
-    st_CudaArgument_get_ptr_raw_argument.argtypes = [ st_CudaArgument_p ]
+    st_CudaArgument_get_ptr_raw_argument.argtypes = [st_CudaArgument_p]
 
     st_CudaArgument_get_size = sixtracklib.st_CudaArgument_get_size
     st_CudaArgument_get_size.restype = ct.c_uint64
-    st_CudaArgument_get_size.argtypes = [ st_CudaArgument_p ]
+    st_CudaArgument_get_size.argtypes = [st_CudaArgument_p]
 
     st_CudaArgument_get_capacity = sixtracklib.st_CudaArgument_get_capacity
     st_CudaArgument_get_capacity.restype = ct.c_uint64
-    st_CudaArgument_get_capacity.argtypes = [ st_CudaArgument_p ]
+    st_CudaArgument_get_capacity.argtypes = [st_CudaArgument_p]
 
     st_CudaArgument_has_argument_buffer = \
         sixtracklib.st_CudaArgument_has_argument_buffer
     st_CudaArgument_has_argument_buffer.restype = ct.c_bool
-    st_CudaArgument_has_argument_buffer.argtypes = [ st_CudaArgument_p ]
+    st_CudaArgument_has_argument_buffer.argtypes = [st_CudaArgument_p]
 
     st_CudaArgument_requires_argument_buffer = \
         sixtracklib.st_CudaArgument_requires_argument_buffer
     st_CudaArgument_requires_argument_buffer.restype = ct.c_bool
-    st_CudaArgument_requires_argument_buffer.argtypes = [ st_CudaArgument_p ]
+    st_CudaArgument_requires_argument_buffer.argtypes = [st_CudaArgument_p]
 
     st_CudaArgument_get_type_id = sixtracklib.st_CudaArgument_get_type_id
     st_CudaArgument_get_type_id.restype = ct.c_uint64
-    st_CudaArgument_get_type_id.argtypes = [ st_CudaArgument_p ]
+    st_CudaArgument_get_type_id.argtypes = [st_CudaArgument_p]
 
 # -----------------------------------------------------------------------------
 # Cl-Context methods
@@ -661,7 +664,8 @@ st_ClContextBase_select_node = sixtracklib.st_ClContextBase_select_node
 st_ClContextBase_select_node.argtypes = [st_Context_p, ct.c_char_p]
 st_ClContextBase_select_node.restype = None
 
-st_ClContextBase_print_nodes_info = sixtracklib.st_ClContextBase_print_nodes_info
+st_ClContextBase_print_nodes_info = \
+    sixtracklib.st_ClContextBase_print_nodes_info
 st_ClContextBase_print_nodes_info.argtypes = [st_Context_p]
 st_ClContextBase_print_nodes_info.restype = None
 
@@ -691,16 +695,22 @@ st_Track_all_particles_element_by_element_until_turn.argtypes = [
 
 st_Particles_extract_addresses_cuda = \
     sixtracklib.st_Particles_extract_addresses_cuda
-st_Particles_extract_addresses_cuda.argtypes = [ ct.c_void_p, ct.c_void_p ]
+st_Particles_extract_addresses_cuda.argtypes = [ct.c_void_p, ct.c_void_p]
 st_Particles_extract_addresses_cuda.restype = ct.c_int32
 
 st_Track_particles_line_cuda_on_grid = \
     sixtracklib.st_Track_particles_line_cuda_on_grid
 st_Track_particles_line_cuda_on_grid.restype = ct.c_int32
-st_Track_particles_line_cuda_on_grid.argtypes = [ ct.c_void_p, ct.c_void_p,
-    ct.c_uint64, ct.c_uint64, ct.c_bool, ct.c_uint64, ct.c_uint64 ]
+st_Track_particles_line_cuda_on_grid.argtypes = [
+    ct.c_void_p,
+    ct.c_void_p,
+    ct.c_uint64,
+    ct.c_uint64,
+    ct.c_bool,
+    ct.c_uint64,
+    ct.c_uint64]
 
 st_Track_particles_line_cuda = sixtracklib.st_Track_particles_line_cuda
 st_Track_particles_line_cuda.restype = ct.c_int32
-st_Track_particles_line_cuda.argtypes = [ ct.c_void_p, ct.c_void_p,
-    ct.c_uint64, ct.c_uint64, ct.c_bool ]
+st_Track_particles_line_cuda.argtypes = [ct.c_void_p, ct.c_void_p,
+                                         ct.c_uint64, ct.c_uint64, ct.c_bool]

--- a/python/pysixtracklib/trackjob.py
+++ b/python/pysixtracklib/trackjob.py
@@ -2,7 +2,7 @@
 # -*- coding: utf-8 -*-
 
 import ctypes as ct
-from cobjects import CBuffer,CObject
+from cobjects import CBuffer, CObject
 
 from . import stcommon as st
 from . import config as stconf
@@ -10,14 +10,15 @@ from .particles import ParticlesSet
 
 
 def _get_buffer(obj):
-    if isinstance(obj,CBuffer):
+    if isinstance(obj, CBuffer):
         return obj
-    elif isinstance(obj,CObject):
+    elif isinstance(obj, CObject):
         return obj._buffer
-    elif hasattr(obj,'cbuffer'):
+    elif hasattr(obj, 'cbuffer'):
         return obj.cbuffer
     else:
         raise ValueError("Object {obj} is not or has not a CBuffer")
+
 
 class TrackJob(object):
     @staticmethod
@@ -63,7 +64,7 @@ class TrackJob(object):
         success = False
 
         if particles_buffer is not None:
-            particles_buffer=_get_buffer(particles_buffer)
+            particles_buffer = _get_buffer(particles_buffer)
             self._particles_buffer = particles_buffer
             self._ptr_c_particles_buffer = \
                 st.st_Buffer_new_mapped_on_cbuffer(particles_buffer)
@@ -71,7 +72,7 @@ class TrackJob(object):
                 raise ValueError("Issues with input particles buffer")
 
         if beam_elements_buffer is not None:
-            beam_elements_buffer=_get_buffer(beam_elements_buffer)
+            beam_elements_buffer = _get_buffer(beam_elements_buffer)
             self._beam_elements_buffer = beam_elements_buffer
             self._ptr_c_beam_elements_buffer = \
                 st.st_Buffer_new_mapped_on_cbuffer(beam_elements_buffer)
@@ -142,7 +143,7 @@ class TrackJob(object):
                (not needs_output_buffer))
 
         if device is not None:
-            arch,device_id=device.split(':')
+            arch, device_id = device.split(':')
 
         arch = arch.strip().lower()
         if not(stconf.SIXTRACKLIB_MODULES.get(arch, False) is not False

--- a/sixtracklib/common/beam_elements.h
+++ b/sixtracklib/common/beam_elements.h
@@ -25,35 +25,45 @@ extern "C" {
 
 /* ========================================================================= */
 
-SIXTRL_FN SIXTRL_STATIC bool NS(BeamElements_is_beam_element_obj)(
+SIXTRL_STATIC SIXTRL_FN bool NS(BeamElements_is_beam_element_obj)(
     SIXTRL_BUFFER_OBJ_ARGPTR_DEC const NS(Object) *const SIXTRL_RESTRICT obj );
 
-SIXTRL_FN SIXTRL_STATIC int NS(BeamElements_calc_buffer_parameters_for_object)(
+SIXTRL_STATIC SIXTRL_FN bool
+NS(BeamElements_objects_range_are_all_beam_elements)(
+    SIXTRL_BUFFER_OBJ_ARGPTR_DEC NS(Object) const* SIXTRL_RESTRICT obj_it,
+    SIXTRL_BUFFER_OBJ_ARGPTR_DEC NS(Object) const* SIXTRL_RESTRICT obj_end );
+
+SIXTRL_STATIC SIXTRL_FN bool
+NS(BeamElements_managed_buffer_is_beam_elements_buffer)(
+    SIXTRL_BUFFER_DATAPTR_DEC unsigned char const* SIXTRL_RESTRICT buffer,
+    NS(buffer_size_t) const slot_size );
+
+SIXTRL_STATIC SIXTRL_FN int NS(BeamElements_calc_buffer_parameters_for_object)(
     SIXTRL_BUFFER_OBJ_ARGPTR_DEC const NS(Object) *const SIXTRL_RESTRICT obj,
     SIXTRL_BUFFER_ARGPTR_DEC NS(buffer_size_t)* SIXTRL_RESTRICT num_objects,
     SIXTRL_BUFFER_ARGPTR_DEC NS(buffer_size_t)* SIXTRL_RESTRICT num_slots,
     SIXTRL_BUFFER_ARGPTR_DEC NS(buffer_size_t)* SIXTRL_RESTRICT num_dataptrs,
     NS(buffer_size_t) const slot_size );
 
-SIXTRL_FN SIXTRL_STATIC int NS(BeamElements_copy_object)(
+SIXTRL_STATIC SIXTRL_FN int NS(BeamElements_copy_object)(
     SIXTRL_BUFFER_OBJ_ARGPTR_DEC NS(Object)* SIXTRL_RESTRICT destination,
     SIXTRL_BUFFER_OBJ_ARGPTR_DEC const NS(Object) *const SIXTRL_RESTRICT src );
 
-SIXTRL_FN SIXTRL_STATIC int NS(BeamElements_compare_objects)(
+SIXTRL_STATIC SIXTRL_FN int NS(BeamElements_compare_objects)(
     SIXTRL_BUFFER_OBJ_ARGPTR_DEC const NS(Object) *const SIXTRL_RESTRICT lhs,
     SIXTRL_BUFFER_OBJ_ARGPTR_DEC const NS(Object) *const SIXTRL_RESTRICT rhs );
 
-SIXTRL_FN SIXTRL_STATIC int NS(BeamElements_compare_objects_with_treshold)(
+SIXTRL_STATIC SIXTRL_FN int NS(BeamElements_compare_objects_with_treshold)(
     SIXTRL_BUFFER_OBJ_ARGPTR_DEC const NS(Object) *const SIXTRL_RESTRICT lhs,
     SIXTRL_BUFFER_OBJ_ARGPTR_DEC const NS(Object) *const SIXTRL_RESTRICT rhs,
     SIXTRL_REAL_T const treshold );
 
-SIXTRL_FN SIXTRL_STATIC void NS(BeamElements_clear_object)(
+SIXTRL_STATIC SIXTRL_FN void NS(BeamElements_clear_object)(
     SIXTRL_BUFFER_OBJ_ARGPTR_DEC NS(Object)* SIXTRL_RESTRICT obj );
 
 /* ------------------------------------------------------------------------ */
 
-SIXTRL_FN SIXTRL_STATIC int NS(BeamElements_calc_buffer_parameters_for_line)(
+SIXTRL_STATIC SIXTRL_FN int NS(BeamElements_calc_buffer_parameters_for_line)(
     SIXTRL_BUFFER_OBJ_ARGPTR_DEC NS(Object) const* SIXTRL_RESTRICT begin,
     SIXTRL_BUFFER_OBJ_ARGPTR_DEC NS(Object) const* SIXTRL_RESTRICT end,
     SIXTRL_BUFFER_ARGPTR_DEC NS(buffer_size_t)* SIXTRL_RESTRICT num_objects,
@@ -61,17 +71,17 @@ SIXTRL_FN SIXTRL_STATIC int NS(BeamElements_calc_buffer_parameters_for_line)(
     SIXTRL_BUFFER_ARGPTR_DEC NS(buffer_size_t)* SIXTRL_RESTRICT num_dataptrs,
     NS(buffer_size_t) const slot_size );
 
-SIXTRL_FN SIXTRL_STATIC int NS(BeamElements_copy_line)(
+SIXTRL_STATIC SIXTRL_FN int NS(BeamElements_copy_line)(
     SIXTRL_BUFFER_OBJ_ARGPTR_DEC NS(Object) const* SIXTRL_RESTRICT begin,
     SIXTRL_BUFFER_OBJ_ARGPTR_DEC NS(Object) const* SIXTRL_RESTRICT end,
     SIXTRL_BUFFER_OBJ_ARGPTR_DEC NS(Object)* SIXTRL_RESTRICT destination_begin );
 
-SIXTRL_FN SIXTRL_STATIC int NS(BeamElements_compare_lines)(
+SIXTRL_STATIC SIXTRL_FN int NS(BeamElements_compare_lines)(
     SIXTRL_BUFFER_OBJ_ARGPTR_DEC NS(Object) const* SIXTRL_RESTRICT begin,
     SIXTRL_BUFFER_OBJ_ARGPTR_DEC NS(Object) const* SIXTRL_RESTRICT end,
     SIXTRL_BUFFER_OBJ_ARGPTR_DEC NS(Object) const* SIXTRL_RESTRICT rhs_begin );
 
-SIXTRL_FN SIXTRL_STATIC int NS(BeamElements_compare_lines_with_treshold)(
+SIXTRL_STATIC SIXTRL_FN int NS(BeamElements_compare_lines_with_treshold)(
     SIXTRL_BUFFER_OBJ_ARGPTR_DEC NS(Object) const* SIXTRL_RESTRICT begin,
     SIXTRL_BUFFER_OBJ_ARGPTR_DEC NS(Object) const* SIXTRL_RESTRICT end,
     SIXTRL_BUFFER_OBJ_ARGPTR_DEC NS(Object) const* SIXTRL_RESTRICT rhs_begin,
@@ -81,28 +91,28 @@ SIXTRL_FN SIXTRL_STATIC int NS(BeamElements_compare_lines_with_treshold)(
 
 #if !defined( _GPUCODE )
 
-SIXTRL_FN SIXTRL_STATIC int NS(BeamElements_add_single_new_to_buffer)(
+SIXTRL_STATIC SIXTRL_FN int NS(BeamElements_add_single_new_to_buffer)(
     SIXTRL_BUFFER_ARGPTR_DEC NS(Buffer)* SIXTRL_RESTRICT buffer,
     SIXTRL_BUFFER_OBJ_ARGPTR_DEC const NS(Object) *const SIXTRL_RESTRICT obj );
 
-SIXTRL_FN SIXTRL_STATIC int NS(BeamElements_copy_single_to_buffer)(
+SIXTRL_STATIC SIXTRL_FN int NS(BeamElements_copy_single_to_buffer)(
     SIXTRL_BUFFER_ARGPTR_DEC NS(Buffer)* SIXTRL_RESTRICT buffer,
     SIXTRL_BUFFER_OBJ_ARGPTR_DEC const NS(Object) *const SIXTRL_RESTRICT obj );
 
-SIXTRL_FN SIXTRL_STATIC int NS(BeamElements_add_new_to_buffer)(
+SIXTRL_STATIC SIXTRL_FN int NS(BeamElements_add_new_to_buffer)(
     SIXTRL_BUFFER_ARGPTR_DEC NS(Buffer)* SIXTRL_RESTRICT buffer,
     SIXTRL_BUFFER_OBJ_ARGPTR_DEC NS(Object) const* SIXTRL_RESTRICT begin,
     SIXTRL_BUFFER_OBJ_ARGPTR_DEC NS(Object) const* SIXTRL_RESTRICT end );
 
-SIXTRL_FN SIXTRL_STATIC int NS(BeamElements_copy_to_buffer)(
+SIXTRL_STATIC SIXTRL_FN int NS(BeamElements_copy_to_buffer)(
     SIXTRL_BUFFER_ARGPTR_DEC NS(Buffer)* SIXTRL_RESTRICT buffer,
     SIXTRL_BUFFER_OBJ_ARGPTR_DEC NS(Object) const* SIXTRL_RESTRICT begin,
     SIXTRL_BUFFER_OBJ_ARGPTR_DEC NS(Object) const* SIXTRL_RESTRICT end );
 
-SIXTRL_FN SIXTRL_STATIC void NS(BeamElements_clear_buffer)(
+SIXTRL_STATIC SIXTRL_FN void NS(BeamElements_clear_buffer)(
     SIXTRL_BUFFER_ARGPTR_DEC NS(Buffer)* SIXTRL_RESTRICT buffer );
 
-SIXTRL_FN SIXTRL_STATIC bool NS(BeamElements_is_beam_elements_buffer)(
+SIXTRL_STATIC SIXTRL_FN bool NS(BeamElements_is_beam_elements_buffer)(
     SIXTRL_BUFFER_ARGPTR_DEC const NS(Buffer) *const SIXTRL_RESTRICT buffer );
 
 #endif /* !defined( _GPUCODE ) */
@@ -179,6 +189,31 @@ SIXTRL_INLINE bool NS(BeamElements_is_beam_element_obj)(
     }
 
     return is_beam_element;
+}
+
+SIXTRL_INLINE bool NS(BeamElements_objects_range_are_all_beam_elements)(
+    SIXTRL_BUFFER_OBJ_ARGPTR_DEC NS(Object) const* SIXTRL_RESTRICT obj_it,
+    SIXTRL_BUFFER_OBJ_ARGPTR_DEC NS(Object) const* SIXTRL_RESTRICT obj_end )
+{
+    bool are_all_beam_elements = false;
+
+    if( ( obj_it != SIXTRL_NULLPTR ) && ( obj_end != SIXTRL_NULLPTR ) &&
+        ( ( ( uintptr_t )obj_it ) <= ( uintptr_t )obj_end ) )
+    {
+        /* NOTE: An empty range evaluates as true, this is to allow use
+         * in context of NS(Track_*particle*_line*) to finish empty/zero
+         * length lines*/
+
+        are_all_beam_elements = true;
+
+        while( ( are_all_beam_elements ) && ( obj_it != obj_end ) )
+        {
+            are_all_beam_elements = NS(BeamElements_is_beam_element_obj)(
+                obj_it++ );
+        }
+    }
+
+    return are_all_beam_elements;
 }
 
 SIXTRL_INLINE int NS(BeamElements_calc_buffer_parameters_for_object)(
@@ -874,7 +909,7 @@ SIXTRL_INLINE int NS(BeamElements_compare_objects_with_treshold)(
     return compare_value;
 }
 
-SIXTRL_FN SIXTRL_STATIC void NS(BeamElements_clear_object)(
+SIXTRL_STATIC SIXTRL_FN void NS(BeamElements_clear_object)(
     SIXTRL_BUFFER_OBJ_ARGPTR_DEC NS(Object)* SIXTRL_RESTRICT obj )
 {
     if( obj != SIXTRL_NULLPTR )
@@ -1446,31 +1481,22 @@ SIXTRL_INLINE void NS(BeamElements_clear_buffer)(
 SIXTRL_INLINE bool NS(BeamElements_is_beam_elements_buffer)(
     SIXTRL_BUFFER_ARGPTR_DEC const NS(Buffer) *const SIXTRL_RESTRICT buffer )
 {
-    typedef NS(buffer_size_t) size_t;
-    typedef SIXTRL_BUFFER_OBJ_ARGPTR_DEC NS(Object) const* obj_iter_t;
+    return NS(BeamElements_managed_buffer_is_beam_elements_buffer)(
+        ( unsigned char const* )( uintptr_t )NS(Buffer_get_data_begin_addr)(
+            buffer ), NS(Buffer_get_slot_size)( buffer ) );
+}
 
-    bool is_beam_elements_buffer = (
-        ( buffer != SIXTRL_NULLPTR ) &&
-        ( NS(Buffer_get_num_of_objects)( buffer ) > ( size_t )0u ) );
+SIXTRL_INLINE bool NS(BeamElements_managed_buffer_is_beam_elements_buffer)(
+    SIXTRL_BUFFER_DATAPTR_DEC unsigned char const* SIXTRL_RESTRICT buffer,
+    NS(buffer_size_t) const slot_size )
+{
+    SIXTRL_ASSERT( buffer != SIXTRL_NULLPTR );
+    SIXTRL_ASSERT( slot_size > ( NS(buffer_size_t) )0u );
+    SIXTRL_ASSERT( !NS(ManagedBuffer_needs_remapping)( buffer, slot_size ) );
 
-    SIXTRL_ASSERT( !NS(Buffer_needs_remapping)( buffer ) );
-
-    if( is_beam_elements_buffer )
-    {
-        obj_iter_t it  = NS(Buffer_get_const_objects_begin)( buffer );
-        obj_iter_t end = NS(Buffer_get_const_objects_end)( buffer );
-
-        for( ; it != end ; ++it )
-        {
-            if( !NS(BeamElements_is_beam_element_obj)( it ) )
-            {
-                is_beam_elements_buffer = false;
-                break;
-            }
-        }
-    }
-
-    return is_beam_elements_buffer;
+    return NS(BeamElements_objects_range_are_all_beam_elements)(
+        NS(ManagedBuffer_get_const_objects_index_begin)( buffer, slot_size ),
+        NS(ManagedBuffer_get_const_objects_index_end)( buffer, slot_size ) );
 }
 
 #endif /* !defined( _GPUCODE ) */

--- a/sixtracklib/common/internal/track_job.cpp
+++ b/sixtracklib/common/internal/track_job.cpp
@@ -263,7 +263,7 @@ namespace SIXTRL_CXX_NAMESPACE
 
 
 int NS(TrackJob_extract_device_id_str)( const char *const SIXTRL_RESTRICT conf,
-    char* SIXTRL_RESTRICT device_id_str, NS(buffer_size_t) const max_str_len )
+    char* SIXTRL_RESTRICT device_id_str, ::NS(buffer_size_t) const max_str_len )
 {
     int success = -1;
     using buf_size_t = ::NS(buffer_size_t);
@@ -306,7 +306,7 @@ int NS(TrackJob_extract_device_id_str)( const char *const SIXTRL_RESTRICT conf,
 }
 
 int NS(TrackJob_sanitize_arch_str_inplace)( char* SIXTRL_RESTRICT arch_str,
-        NS(buffer_size_t) const max_str_len )
+        ::NS(buffer_size_t) const max_str_len )
 {
     int success = -1;
     using buf_size_t = ::NS(buffer_size_t);
@@ -328,9 +328,10 @@ int NS(TrackJob_sanitize_arch_str_inplace)( char* SIXTRL_RESTRICT arch_str,
     return success;
 }
 
-int NS(TrackJob_sanitize_arch_str)( const char *const SIXTRL_RESTRICT arch_str,
-        char* SIXTRL_RESTRICT sanitized_arch_str,
-        NS(buffer_size_t) const max_out_str_len )
+int NS(TrackJob_sanitize_arch_str)(
+    const char *const SIXTRL_RESTRICT arch_str,
+    char* SIXTRL_RESTRICT sanitized_arch_str,
+    ::NS(buffer_size_t) const max_out_str_len )
 {
     int success = -1;
     using buf_size_t = ::NS(buffer_size_t);
@@ -356,27 +357,28 @@ int NS(TrackJob_sanitize_arch_str)( const char *const SIXTRL_RESTRICT arch_str,
 
 /* - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - */
 
-NS(TrackJobBase)* NS(TrackJob_create)( const char *const SIXTRL_RESTRICT arch,
+::NS(TrackJobBase)* NS(TrackJob_create)(
+    const char *const SIXTRL_RESTRICT arch,
     const char *const SIXTRL_RESTRICT config_str )
 {
     return SIXTRL_CXX_NAMESPACE::TrackJob_create( arch, config_str );
 }
 
-NS(TrackJobBase)* NS(TrackJob_new)( const char *const SIXTRL_RESTRICT arch,
-    NS(Buffer)* SIXTRL_RESTRICT particles_buffer,
-    NS(Buffer)* SIXTRL_RESTRICT beam_elem_buffer,
+::NS(TrackJobBase)* NS(TrackJob_new)( const char *const SIXTRL_RESTRICT arch,
+    ::NS(Buffer)* SIXTRL_RESTRICT particles_buffer,
+    ::NS(Buffer)* SIXTRL_RESTRICT beam_elem_buffer,
     const char *const SIXTRL_RESTRICT config_str )
 {
     return SIXTRL_CXX_NAMESPACE::TrackJob_new(
         arch, particles_buffer, beam_elem_buffer, config_str );
 }
 
-NS(TrackJobBase)* NS(TrackJob_new_with_output)(
+::NS(TrackJobBase)* NS(TrackJob_new_with_output)(
     const char *const SIXTRL_RESTRICT arch,
-    NS(Buffer)* SIXTRL_RESTRICT particles_buffer,
-    NS(Buffer)* SIXTRL_RESTRICT beam_elem_buffer,
-    NS(Buffer)* SIXTRL_RESTRICT output_buffer,
-    NS(buffer_size_t) const dump_elem_by_elem_turns,
+    ::NS(Buffer)* SIXTRL_RESTRICT particles_buffer,
+    ::NS(Buffer)* SIXTRL_RESTRICT beam_elem_buffer,
+    ::NS(Buffer)* SIXTRL_RESTRICT output_buffer,
+    ::NS(buffer_size_t) const dump_elem_by_elem_turns,
     const char *const SIXTRL_RESTRICT config_str )
 {
     return SIXTRL_CXX_NAMESPACE::TrackJob_new(
@@ -384,14 +386,14 @@ NS(TrackJobBase)* NS(TrackJob_new_with_output)(
             dump_elem_by_elem_turns, config_str );
 }
 
-NS(TrackJobBase)* NS(TrackJob_new_detailed)(
+::NS(TrackJobBase)* NS(TrackJob_new_detailed)(
     const char *const SIXTRL_RESTRICT arch,
-    NS(Buffer)* SIXTRL_RESTRICT particles_buffer,
-    NS(buffer_size_t) const num_particle_sets,
-    NS(buffer_size_t) const* SIXTRL_RESTRICT pset_indices_begin,
-    NS(Buffer)* SIXTRL_RESTRICT beam_elem_buffer,
-    NS(Buffer)* SIXTRL_RESTRICT output_buffer,
-    NS(buffer_size_t) const dump_elem_by_elem_turns,
+    ::NS(Buffer)* SIXTRL_RESTRICT particles_buffer,
+    ::NS(buffer_size_t) const num_particle_sets,
+    ::NS(buffer_size_t) const* SIXTRL_RESTRICT pset_indices_begin,
+    ::NS(Buffer)* SIXTRL_RESTRICT beam_elem_buffer,
+    ::NS(Buffer)* SIXTRL_RESTRICT output_buffer,
+    ::NS(buffer_size_t) const dump_elem_by_elem_turns,
     const char *const SIXTRL_RESTRICT config_str )
 {
     return SIXTRL_CXX_NAMESPACE::TrackJob_new( arch, particles_buffer,
@@ -401,31 +403,33 @@ NS(TrackJobBase)* NS(TrackJob_new_detailed)(
 
 /* ------------------------------------------------------------------------- */
 
-void NS(TrackJob_delete)( NS(TrackJobBase)* SIXTRL_RESTRICT job )
+void NS(TrackJob_delete)( ::NS(TrackJobBase)* SIXTRL_RESTRICT job )
 {
     if( job != nullptr ) delete job;
 }
 
-NS(track_status_t) NS(TrackJob_track_until)(
-    NS(TrackJobBase)* SIXTRL_RESTRICT job, NS(buffer_size_t) const until_turn )
+::NS(track_status_t) NS(TrackJob_track_until)(
+    ::NS(TrackJobBase)* SIXTRL_RESTRICT job,
+    ::NS(buffer_size_t) const until_turn )
 {
     return ( job != nullptr )
         ? job->track( until_turn )
         : ::NS(track_status_t){ -1 };
 }
 
-NS(track_status_t) NS(TrackJob_track_elem_by_elem)(
-    NS(TrackJobBase)* SIXTRL_RESTRICT job, NS(buffer_size_t) const until_turn )
+::NS(track_status_t) NS(TrackJob_track_elem_by_elem)(
+    ::NS(TrackJobBase)* SIXTRL_RESTRICT job,
+    ::NS(buffer_size_t) const until_turn )
 {
     return ( job != nullptr )
         ? job->trackElemByElem( until_turn )
         : ::NS(track_status_t){ -1 };
 }
 
-SIXTRL_EXTERN NS(track_status_t) NS(TrackJob_track_line)(
-    NS(TrackJobBase)* SIXTRL_RESTRICT job,
-    NS(buffer_size_t) const beam_elem_begin_index,
-    NS(buffer_size_t) const beam_elem_end_index,
+::NS(track_status_t) NS(TrackJob_track_line)(
+    ::NS(TrackJobBase)* SIXTRL_RESTRICT job,
+    ::NS(buffer_size_t) const beam_elem_begin_index,
+    ::NS(buffer_size_t) const beam_elem_end_index,
     bool const finish_turn )
 {
     return ( job != nullptr )
@@ -434,11 +438,110 @@ SIXTRL_EXTERN NS(track_status_t) NS(TrackJob_track_line)(
         : ::NS(track_status_t){ -1 };
 }
 
-void NS(TrackJob_collect)( NS(TrackJobBase)* SIXTRL_RESTRICT job )
+/* ------------------------------------------------------------------------- */
+
+void NS(TrackJob_collect)( ::NS(TrackJobBase)* SIXTRL_RESTRICT job )
 {
     if( job != nullptr ) job->collect();
-    return;
 }
+
+void NS(TrackJob_collect_detailed)( ::NS(TrackJobBase)* SIXTRL_RESTRICT job,
+    ::NS(track_job_collect_flag_t) const flags )
+{
+    if( job != nullptr ) job->collect( flags );
+}
+
+void NS(TrackJob_collect_particles)( ::NS(TrackJobBase)* SIXTRL_RESTRICT job )
+{
+    if( job != nullptr ) job->collectParticles();
+}
+
+void NS(TrackJob_collect_beam_elements)(
+    ::NS(TrackJobBase)* SIXTRL_RESTRICT job )
+{
+    if( job != nullptr ) job->collectBeamElements();
+}
+
+void NS(TrackJob_collect_output)( ::NS(TrackJobBase)* SIXTRL_RESTRICT job )
+{
+    if( job != nullptr ) job->collectOutput();
+}
+
+void NS(TrackJob_enable_collect_particles)(
+    ::NS(TrackJobBase)* SIXTRL_RESTRICT job )
+{
+    if( job != nullptr ) job->enableCollectParticles();
+}
+
+void NS(TrackJob_disable_collect_particles)(
+    ::NS(TrackJobBase)* SIXTRL_RESTRICT job )
+{
+    if( job != nullptr ) job->disableCollectParticles();
+}
+
+bool NS(TrackJob_is_collecting_particles)(
+    const ::NS(TrackJobBase) *const SIXTRL_RESTRICT job )
+{
+    return ( job != nullptr ) ? job->isCollectingParticles() : false;
+}
+
+void NS(TrackJob_enable_collect_beam_elements)(
+    ::NS(TrackJobBase)* SIXTRL_RESTRICT job )
+{
+    if( job != nullptr ) job->enableCollectBeamElements();
+}
+
+void NS(TrackJob_disable_collect_beam_elements)(
+    ::NS(TrackJobBase)* SIXTRL_RESTRICT job )
+{
+    if( job != nullptr ) job->disableCollectBeamElements();
+}
+
+bool NS(TrackJob_is_collecting_beam_elements)(
+    const ::NS(TrackJobBase) *const SIXTRL_RESTRICT job )
+{
+    return ( job != nullptr ) ? job->isCollectingBeamElements() : false;
+}
+
+void NS(TrackJob_enable_collect_output)(
+    ::NS(TrackJobBase)* SIXTRL_RESTRICT job )
+{
+    if( job != nullptr ) job->enableCollectOutput();
+}
+
+void NS(TrackJob_disable_collect_output)(
+    ::NS(TrackJobBase)* SIXTRL_RESTRICT job )
+{
+    if( job != nullptr ) job->disableCollectOutput();
+}
+
+bool NS(TrackJob_is_collecting_output)(
+    const ::NS(TrackJobBase) *const SIXTRL_RESTRICT job )
+{
+    return ( job != nullptr ) ? job->isCollectingOutput() : false;
+}
+
+::NS(track_job_collect_flag_t) NS(TrackJob_get_collect_flags)(
+    const ::NS(TrackJobBase) *const SIXTRL_RESTRICT job )
+{
+    return ( job != nullptr )
+        ? job->collectFlags() : ::NS(TRACK_JOB_COLLECT_DEFAULT_FLAGS);
+}
+
+void NS(TrackJob_set_collect_flags)(
+    ::NS(TrackJobBase)* SIXTRL_RESTRICT job,
+    ::NS(track_job_collect_flag_t) const flags )
+{
+    if( job != nullptr ) job->setCollectFlags( flags );
+}
+
+bool NS(TrackJob_requires_collecting)(
+    const ::NS(TrackJobBase) *const SIXTRL_RESTRICT job )
+{
+    return ( job != nullptr ) ? job->requiresCollecting() : false;
+}
+
+/* ------------------------------------------------------------------------- */
 
 void NS(TrackJob_clear)( NS(TrackJobBase)* SIXTRL_RESTRICT job )
 {
@@ -454,6 +557,17 @@ bool NS(TrackJob_reset)( NS(TrackJobBase)* SIXTRL_RESTRICT job,
         ? job->reset( particles_buffer, beam_elem_buffer, ptr_output_buffer )
         : false;
 }
+
+bool NS(TrackJob_reset_particle_set)( ::NS(TrackJobBase)* SIXTRL_RESTRICT job,
+    ::NS(Buffer)* SIXTRL_RESTRICT particles_buffer,
+    ::NS(buffer_size_t) const particle_set_index,
+    ::NS(Buffer)* SIXTRL_RESTRICT beam_elem_buffer,
+    ::NS(Buffer)* SIXTRL_RESTRICT output_buffer )
+{
+    return ( job != nullptr ) ? job->reset( particles_buffer,
+        particle_set_index, beam_elem_buffer, output_buffer ) : false;
+}
+
 
 bool NS(TrackJob_reset_with_output)( NS(TrackJobBase)* SIXTRL_RESTRICT job,
     NS(Buffer)* SIXTRL_RESTRICT particles_buffer,
@@ -479,6 +593,13 @@ bool NS(TrackJob_reset_detailed)( NS(TrackJobBase)* SIXTRL_RESTRICT job,
             particle_set_indices_begin, beam_elem_buffer, output_buffer,
                 dump_elem_by_elem_turns )
         : false;
+}
+
+bool NS(TrackJob_select_particle_set)( NS(TrackJobBase)* SIXTRL_RESTRICT job,
+    NS(buffer_size_t) const particle_set_index )
+{
+    return ( job != nullptr )
+        ? job->selectParticleSet( particle_set_index ) : false;
 }
 
 bool NS(TrackJob_assign_output_buffer)( NS(TrackJobBase)* SIXTRL_RESTRICT job,

--- a/sixtracklib/common/internal/track_job_base.cpp
+++ b/sixtracklib/common/internal/track_job_base.cpp
@@ -2,6 +2,7 @@
 
 #if !defined( SIXTRL_NO_SYSTEM_INCLUDES )
     #if defined( __cplusplus )
+        #include <algorithm>
         #include <cstddef>
         #include <cstdint>
         #include <cstdlib>
@@ -18,6 +19,9 @@
 #endif /* !defined( SIXTRL_NO_SYSTEM_INCLUDES ) */
 
 #if !defined( SIXTRL_NO_INCLUDES )
+    #include "sixtracklib/common/definitions.h"
+    #include "sixtracklib/common/track/definitions.h"
+
     #if defined( __cplusplus )
         #include "sixtracklib/common/buffer.hpp"
     #endif /* defined( __cplusplus ) */
@@ -36,31 +40,157 @@
 
 namespace SIXTRL_CXX_NAMESPACE
 {
-    SIXTRL_HOST_FN void TrackJobBase::clear()
+    TrackJobBase::size_type
+    TrackJobBase::DefaultNumParticleSetIndices() SIXTRL_NOEXCEPT
+    {
+        return SIXTRL_CXX_NAMESPACE::TRACK_JOB_DEFAULT_NUM_PARTICLE_SETS;
+    }
+
+    TrackJobBase::size_type const*
+    TrackJobBase::DefaultParticleSetIndicesBegin() SIXTRL_NOEXCEPT
+    {
+        TrackJobBase::size_type const* ptr =
+            &SIXTRL_CXX_NAMESPACE::TRACK_JOB_DEFAULT_PARTICLE_SET_INDICES[ 0 ];
+        return ptr;
+    }
+
+    TrackJobBase::size_type const*
+    TrackJobBase::DefaultParticleSetIndicesEnd() SIXTRL_NOEXCEPT
+    {
+        TrackJobBase::size_type const* end_ptr =
+            TrackJobBase::DefaultParticleSetIndicesBegin();
+
+        std::advance( end_ptr,
+            SIXTRL_CXX_NAMESPACE::TRACK_JOB_DEFAULT_NUM_PARTICLE_SETS );
+
+        return end_ptr;
+    }
+
+    void TrackJobBase::clear()
     {
         this->doClear();
         return;
     }
 
-    SIXTRL_HOST_FN void TrackJobBase::collect()
+    /* --------------------------------------------------------------------- */
+
+    void TrackJobBase::collect()
     {
-        this->doCollect();
-        return;
+        this->doCollect( this->m_collect_flags );
     }
 
-    SIXTRL_HOST_FN TrackJobBase::track_status_t TrackJobBase::track(
+    void TrackJobBase::collect( TrackJobBase::collect_flag_t const flags )
+    {
+        this->doCollect( flags & SIXTRL_CXX_NAMESPACE::TRACK_JOB_COLLECT_ALL );
+    }
+
+    void TrackJobBase::collectParticles()
+    {
+        this->doCollect( SIXTRL_CXX_NAMESPACE::TRACK_JOB_COLLECT_PARTICLES );
+    }
+
+
+    void TrackJobBase::collectBeamElements()
+    {
+        this->doCollect(
+            SIXTRL_CXX_NAMESPACE::TRACK_JOB_COLLECT_BEAM_ELEMENTS );
+    }
+
+    void TrackJobBase::collectOutput()
+    {
+        this->doCollect( SIXTRL_CXX_NAMESPACE::TRACK_JOB_COLLECT_OUTPUT );
+    }
+
+    void TrackJobBase::enableCollectParticles()  SIXTRL_NOEXCEPT
+    {
+        this->m_collect_flags |=
+            SIXTRL_CXX_NAMESPACE::TRACK_JOB_COLLECT_PARTICLES;
+    }
+
+    void TrackJobBase::disableCollectParticles() SIXTRL_NOEXCEPT
+    {
+        this->m_collect_flags = TrackJobBase::UnsetCollectFlag(
+            this->m_collect_flags,
+            SIXTRL_CXX_NAMESPACE::TRACK_JOB_COLLECT_PARTICLES );
+    }
+
+    bool TrackJobBase::isCollectingParticles() const SIXTRL_NOEXCEPT
+    {
+        return TrackJobBase::IsCollectFlagSet( this->m_collect_flags,
+            SIXTRL_CXX_NAMESPACE::TRACK_JOB_COLLECT_PARTICLES );
+    }
+
+    void TrackJobBase::enableCollectBeamElements()  SIXTRL_NOEXCEPT
+    {
+        this->m_collect_flags |=
+            SIXTRL_CXX_NAMESPACE::TRACK_JOB_COLLECT_BEAM_ELEMENTS;
+    }
+
+    void TrackJobBase::disableCollectBeamElements() SIXTRL_NOEXCEPT
+    {
+        this->m_collect_flags = TrackJobBase::UnsetCollectFlag(
+            this->m_collect_flags,
+            SIXTRL_CXX_NAMESPACE::TRACK_JOB_COLLECT_BEAM_ELEMENTS );
+    }
+
+    bool TrackJobBase::isCollectingBeamElements() const SIXTRL_NOEXCEPT
+    {
+        return TrackJobBase::IsCollectFlagSet( this->m_collect_flags,
+                SIXTRL_CXX_NAMESPACE::TRACK_JOB_COLLECT_BEAM_ELEMENTS );
+    }
+
+    void TrackJobBase::enableCollectOutput()  SIXTRL_NOEXCEPT
+    {
+        this->m_collect_flags |=
+            SIXTRL_CXX_NAMESPACE::TRACK_JOB_COLLECT_OUTPUT;
+    }
+
+    void TrackJobBase::disableCollectOutput() SIXTRL_NOEXCEPT
+    {
+        this->m_collect_flags = TrackJobBase::UnsetCollectFlag(
+            this->m_collect_flags,
+            SIXTRL_CXX_NAMESPACE::TRACK_JOB_COLLECT_OUTPUT );
+    }
+
+    bool TrackJobBase::isCollectingOutput() const SIXTRL_NOEXCEPT
+    {
+        return TrackJobBase::IsCollectFlagSet( this->m_collect_flags,
+                SIXTRL_CXX_NAMESPACE::TRACK_JOB_COLLECT_OUTPUT );
+    }
+
+    TrackJobBase::collect_flag_t
+    TrackJobBase::collectFlags() const SIXTRL_NOEXCEPT
+    {
+        return this->m_collect_flags;
+    }
+
+    void TrackJobBase::setCollectFlags( TrackJobBase::collect_flag_t
+        const flags ) SIXTRL_NOEXCEPT
+    {
+        this->m_collect_flags = ( flags &
+            SIXTRL_CXX_NAMESPACE::TRACK_JOB_COLLECT_ALL );
+    }
+
+    bool TrackJobBase::requiresCollecting() const SIXTRL_NOEXCEPT
+    {
+        return this->m_requires_collect;
+    }
+
+    /* --------------------------------------------------------------------- */
+
+    TrackJobBase::track_status_t TrackJobBase::track(
         TrackJobBase::size_type const until_turn )
     {
         return this->doTrackUntilTurn( until_turn );
     }
 
-    SIXTRL_HOST_FN TrackJobBase::track_status_t TrackJobBase::trackElemByElem(
+    TrackJobBase::track_status_t TrackJobBase::trackElemByElem(
         TrackJobBase::size_type const until_turn )
     {
         return this->doTrackElemByElem( until_turn );
     }
 
-    SIXTRL_HOST_FN TrackJobBase::track_status_t TrackJobBase::trackLine(
+    TrackJobBase::track_status_t TrackJobBase::trackLine(
         TrackJobBase::size_type const beam_elements_begin_index,
         TrackJobBase::size_type const beam_elements_end_index,
         bool const finish_turn )
@@ -69,7 +199,7 @@ namespace SIXTRL_CXX_NAMESPACE
             beam_elements_begin_index, beam_elements_end_index, finish_turn );
     }
 
-    SIXTRL_HOST_FN bool TrackJobBase::reset(
+    bool TrackJobBase::reset(
         TrackJobBase::buffer_t& SIXTRL_RESTRICT_REF particles_buffer,
         TrackJobBase::buffer_t& SIXTRL_RESTRICT_REF be_buffer,
         TrackJobBase::buffer_t* SIXTRL_RESTRICT ptr_output_buffer,
@@ -101,7 +231,24 @@ namespace SIXTRL_CXX_NAMESPACE
         return success;
     }
 
-    SIXTRL_HOST_FN bool TrackJobBase::reset(
+    bool TrackJobBase::reset(
+        TrackJobBase::buffer_t& SIXTRL_RESTRICT_REF particles_buffer,
+        TrackJobBase::size_type const particle_set_index,
+        TrackJobBase::buffer_t& SIXTRL_RESTRICT_REF be_buffer,
+        TrackJobBase::buffer_t* SIXTRL_RESTRICT ptr_output_buffer,
+        TrackJobBase::size_type const until_turn_elem_by_elem )
+    {
+        using size_t = TrackJobBase::size_type;
+
+        size_t particle_set_indices[] = { size_t{ 0 } };
+        particle_set_indices[ 0 ] = particle_set_index;
+
+        return TrackJobBase::reset( particles_buffer,
+            &particle_set_indices[ 0 ], &particle_set_indices[ 1 ], be_buffer,
+                ptr_output_buffer, until_turn_elem_by_elem );
+    }
+
+    bool TrackJobBase::reset(
         TrackJobBase::c_buffer_t* SIXTRL_RESTRICT particles_buffer,
         TrackJobBase::c_buffer_t* SIXTRL_RESTRICT be_buffer,
         TrackJobBase::c_buffer_t* SIXTRL_RESTRICT ptr_output_buffer,
@@ -126,7 +273,19 @@ namespace SIXTRL_CXX_NAMESPACE
         return success;
     }
 
-    SIXTRL_HOST_FN bool TrackJobBase::reset(
+    bool TrackJobBase::reset(
+        TrackJobBase::c_buffer_t* SIXTRL_RESTRICT particles_buffer,
+        TrackJobBase::size_type const particle_set_index,
+        TrackJobBase::c_buffer_t* SIXTRL_RESTRICT be_buffer,
+        TrackJobBase::c_buffer_t* SIXTRL_RESTRICT ptr_output_buffer,
+        TrackJobBase::size_type const until_turn_elem_by_elem )
+    {
+        return TrackJobBase::reset( particles_buffer,
+            TrackJobBase::size_type{ 1 }, &particle_set_index, be_buffer,
+                ptr_output_buffer, until_turn_elem_by_elem );
+    }
+
+    bool TrackJobBase::reset(
         TrackJobBase::c_buffer_t* SIXTRL_RESTRICT particles_buffer,
         TrackJobBase::size_type const num_particle_sets,
         TrackJobBase::size_type const* SIXTRL_RESTRICT
@@ -149,7 +308,86 @@ namespace SIXTRL_CXX_NAMESPACE
             be_buffer, ptr_output_buffer, until_turn_elem_by_elem );
     }
 
-    SIXTRL_HOST_FN bool TrackJobBase::assignOutputBuffer(
+    bool TrackJobBase::selectParticleSet(
+        TrackJobBase::size_type const particle_set_index )
+    {
+        using buffer_t   = TrackJobBase::buffer_t;
+        using c_buffer_t = TrackJobBase::c_buffer_t;
+        using size_t = TrackJobBase::size_type;
+
+        bool success = false;
+
+        buffer_t*   ptr_particles_buffer   = this->ptrOutputBuffer();
+        buffer_t*   ptr_beam_elem_buffer   = this->ptrBeamElementsBuffer();
+
+        c_buffer_t* ptr_c_particles_buffer = this->ptrCParticlesBuffer();
+        c_buffer_t* ptr_c_beam_elem_buffer = this->ptrCBeamElementsBuffer();
+
+        if( ( ptr_c_particles_buffer != nullptr ) &&
+            ( !::NS(Buffer_needs_remapping)( ptr_c_particles_buffer ) ) &&
+            ( static_cast< size_t >( ::NS(Buffer_get_num_of_objects)(
+                ptr_c_particles_buffer ) ) > particle_set_index ) &&
+            ( ptr_c_beam_elem_buffer != nullptr ) &&
+            ( !::NS(Buffer_needs_remapping)( ptr_c_beam_elem_buffer ) ) )
+        {
+            buffer_t* ptr_output_buffer = nullptr;
+            c_buffer_t* ptr_c_output_buffer = nullptr;
+
+            if( ( this->hasOutputBuffer() ) && ( !this->ownsOutputBuffer() ) )
+            {
+                ptr_output_buffer   = this->ptrOutputBuffer();
+                ptr_c_output_buffer = this->ptrCOutputBuffer();
+
+                SIXTRL_ASSERT( ::NS(Buffer_needs_remapping)(
+                    ptr_c_output_buffer ) );
+            }
+
+            if( ( ptr_particles_buffer != nullptr ) &&
+                ( ptr_beam_elem_buffer != nullptr ) )
+            {
+                SIXTRL_ASSERT(
+                    ( ( ptr_output_buffer != nullptr ) &&
+                      ( ptr_c_output_buffer != nullptr ) ) ||
+                    ( ( ptr_output_buffer == nullptr ) &&
+                      ( ptr_c_output_buffer == nullptr ) ) );
+
+                SIXTRL_ASSERT(
+                    ( ptr_particles_buffer->getCApiPtr() ==
+                      ptr_c_particles_buffer ) &&
+                    ( ptr_beam_elem_buffer->getCApiPtr() ==
+                      ptr_c_beam_elem_buffer ) );
+
+                if( ptr_c_output_buffer != nullptr )
+                {
+                    ::NS(Buffer_clear)( ptr_c_output_buffer, true );
+                }
+
+                size_t particle_set_indices[ 1 ] = { size_t{ 0 } };
+                particle_set_indices[ 0 ] = particle_set_index;
+
+                success = this->reset( *ptr_particles_buffer,
+                    &particle_set_indices[ 0 ], &particle_set_indices[ 1 ],
+                        *ptr_beam_elem_buffer, ptr_output_buffer,
+                            this->untilTurnElemByElem() );
+            }
+            else if( ( ptr_c_particles_buffer != nullptr ) &&
+                     ( ptr_c_beam_elem_buffer != nullptr ) )
+            {
+                if( ptr_c_output_buffer != nullptr )
+                {
+                    ::NS(Buffer_clear)( ptr_c_output_buffer, true );
+                }
+
+                success = this->reset( ptr_c_particles_buffer, size_t{ 1 },
+                    &particle_set_index, ptr_c_beam_elem_buffer,
+                        ptr_c_output_buffer, this->untilTurnElemByElem() );
+            }
+        }
+
+        return success;
+    }
+
+    bool TrackJobBase::assignOutputBuffer(
         TrackJobBase::buffer_t& SIXTRL_RESTRICT_REF output_buffer )
     {
         bool success = false;
@@ -170,7 +408,7 @@ namespace SIXTRL_CXX_NAMESPACE
         return success;
     }
 
-    SIXTRL_HOST_FN bool TrackJobBase::assignOutputBuffer(
+    bool TrackJobBase::assignOutputBuffer(
         TrackJobBase::c_buffer_t* SIXTRL_RESTRICT ptr_output_buffer )
     {
         return this->doAssignNewOutputBuffer( ptr_output_buffer );
@@ -178,53 +416,53 @@ namespace SIXTRL_CXX_NAMESPACE
 
     /* --------------------------------------------------------------------- */
 
-    SIXTRL_HOST_FN TrackJobBase::type_t
+    TrackJobBase::type_t
     TrackJobBase::type() const SIXTRL_NOEXCEPT
     {
         return this->m_type_id;
     }
 
-    SIXTRL_HOST_FN std::string const&
+    std::string const&
     TrackJobBase::typeStr() const SIXTRL_NOEXCEPT
     {
         return this->m_type_str;
     }
 
-    SIXTRL_HOST_FN char const* TrackJobBase::ptrTypeStr() const SIXTRL_NOEXCEPT
+    char const* TrackJobBase::ptrTypeStr() const SIXTRL_NOEXCEPT
     {
         return this->m_type_str.c_str();
     }
 
-    SIXTRL_HOST_FN bool TrackJobBase::hasDeviceIdStr() const SIXTRL_RESTRICT
+    bool TrackJobBase::hasDeviceIdStr() const SIXTRL_RESTRICT
     {
         return ( !this->m_device_id_str.empty() );
     }
 
-    SIXTRL_HOST_FN std::string const&
+    std::string const&
     TrackJobBase::deviceIdStr() const SIXTRL_NOEXCEPT
     {
         return this->m_device_id_str;
     }
 
-    SIXTRL_HOST_FN char const*
+    char const*
     TrackJobBase::ptrDeviceIdStr() const SIXTRL_NOEXCEPT
     {
         return this->m_device_id_str.c_str();
     }
 
-    SIXTRL_HOST_FN bool
+    bool
     TrackJobBase::hasConfigStr() const SIXTRL_NOEXCEPT
     {
         return ( !this->m_config_str.empty() );
     }
 
-    SIXTRL_HOST_FN std::string const&
+    std::string const&
     TrackJobBase::configStr()   const SIXTRL_NOEXCEPT
     {
         return this->m_config_str;
     }
 
-    SIXTRL_HOST_FN char const*
+    char const*
     TrackJobBase::ptrConfigStr() const SIXTRL_NOEXCEPT
     {
         return this->m_config_str.c_str();
@@ -232,19 +470,19 @@ namespace SIXTRL_CXX_NAMESPACE
 
     /* --------------------------------------------------------------------- */
 
-    SIXTRL_HOST_FN TrackJobBase::size_type
+    TrackJobBase::size_type
     TrackJobBase::numParticleSets() const SIXTRL_NOEXCEPT
     {
         return this->m_particle_set_indices.size();
     }
 
-    SIXTRL_HOST_FN TrackJobBase::size_type const*
+    TrackJobBase::size_type const*
     TrackJobBase::particleSetIndicesBegin() const SIXTRL_NOEXCEPT
     {
         return this->m_particle_set_indices.data();
     }
 
-    SIXTRL_HOST_FN TrackJobBase::size_type const*
+    TrackJobBase::size_type const*
     TrackJobBase::particleSetIndicesEnd() const SIXTRL_NOEXCEPT
     {
         TrackJobBase::size_type const* end_ptr =
@@ -256,7 +494,7 @@ namespace SIXTRL_CXX_NAMESPACE
         return end_ptr;
     }
 
-    SIXTRL_HOST_FN TrackJobBase::size_type TrackJobBase::particleSetIndex(
+    TrackJobBase::size_type TrackJobBase::particleSetIndex(
         TrackJobBase::size_type const n ) const
     {
         return this->m_particle_set_indices.at( n );
@@ -264,37 +502,37 @@ namespace SIXTRL_CXX_NAMESPACE
 
     /* --------------------------------------------------------------------- */
 
-    SIXTRL_HOST_FN TrackJobBase::particle_index_t
+    TrackJobBase::particle_index_t
     TrackJobBase::minParticleId() const SIXTRL_NOEXCEPT
     {
         return this->m_min_particle_id;
     }
 
-    SIXTRL_HOST_FN TrackJobBase::particle_index_t
+    TrackJobBase::particle_index_t
     TrackJobBase::maxParticleId() const SIXTRL_NOEXCEPT
     {
         return this->m_max_particle_id;
     }
 
-    SIXTRL_HOST_FN TrackJobBase::particle_index_t
+    TrackJobBase::particle_index_t
     TrackJobBase::minElementId()  const SIXTRL_NOEXCEPT
     {
         return this->m_min_element_id;
     }
 
-    SIXTRL_HOST_FN TrackJobBase::particle_index_t
+    TrackJobBase::particle_index_t
     TrackJobBase::maxElementId()  const SIXTRL_NOEXCEPT
     {
         return this->m_max_element_id;
     }
 
-    SIXTRL_HOST_FN TrackJobBase::particle_index_t
+    TrackJobBase::particle_index_t
     TrackJobBase::minInitialTurnId() const SIXTRL_NOEXCEPT
     {
         return this->m_min_initial_turn_id;
     }
 
-    SIXTRL_HOST_FN TrackJobBase::particle_index_t
+    TrackJobBase::particle_index_t
     TrackJobBase::maxInitialTurnId() const SIXTRL_NOEXCEPT
     {
         return this->m_max_initial_turn_id;
@@ -302,7 +540,7 @@ namespace SIXTRL_CXX_NAMESPACE
 
     /* --------------------------------------------------------------------- */
 
-    SIXTRL_HOST_FN TrackJobBase::buffer_t*
+    TrackJobBase::buffer_t*
     TrackJobBase::ptrParticlesBuffer() SIXTRL_NOEXCEPT
     {
         using _this_t = TrackJobBase;
@@ -312,7 +550,7 @@ namespace SIXTRL_CXX_NAMESPACE
             *this ).ptrParticlesBuffer() );
     }
 
-    SIXTRL_HOST_FN TrackJobBase::buffer_t const*
+    TrackJobBase::buffer_t const*
     TrackJobBase::ptrParticlesBuffer() const SIXTRL_NOEXCEPT
     {
         SIXTRL_ASSERT(
@@ -323,7 +561,7 @@ namespace SIXTRL_CXX_NAMESPACE
         return this->m_ptr_particles_buffer;
     }
 
-    SIXTRL_HOST_FN TrackJobBase::c_buffer_t*
+    TrackJobBase::c_buffer_t*
     TrackJobBase::ptrCParticlesBuffer() SIXTRL_NOEXCEPT
     {
         using _this_t = TrackJobBase;
@@ -333,7 +571,7 @@ namespace SIXTRL_CXX_NAMESPACE
             *this ).ptrCParticlesBuffer() );
     }
 
-    SIXTRL_HOST_FN TrackJobBase::c_buffer_t const*
+    TrackJobBase::c_buffer_t const*
     TrackJobBase::ptrCParticlesBuffer() const SIXTRL_NOEXCEPT
     {
         SIXTRL_ASSERT(
@@ -346,7 +584,7 @@ namespace SIXTRL_CXX_NAMESPACE
 
     /* --------------------------------------------------------------------- */
 
-    SIXTRL_HOST_FN TrackJobBase::buffer_t*
+    TrackJobBase::buffer_t*
     TrackJobBase::ptrBeamElementsBuffer() SIXTRL_NOEXCEPT
     {
         using _this_t = TrackJobBase;
@@ -356,7 +594,7 @@ namespace SIXTRL_CXX_NAMESPACE
             *this ).ptrBeamElementsBuffer() );
     }
 
-    SIXTRL_HOST_FN TrackJobBase::buffer_t const*
+    TrackJobBase::buffer_t const*
     TrackJobBase::ptrBeamElementsBuffer() const SIXTRL_NOEXCEPT
     {
         SIXTRL_ASSERT(
@@ -367,7 +605,7 @@ namespace SIXTRL_CXX_NAMESPACE
         return this->m_ptr_beam_elem_buffer;
     }
 
-    SIXTRL_HOST_FN TrackJobBase::c_buffer_t*
+    TrackJobBase::c_buffer_t*
     TrackJobBase::ptrCBeamElementsBuffer() SIXTRL_NOEXCEPT
     {
         using _this_t = TrackJobBase;
@@ -377,7 +615,7 @@ namespace SIXTRL_CXX_NAMESPACE
             *this ).ptrCBeamElementsBuffer() );
     }
 
-    SIXTRL_HOST_FN TrackJobBase::c_buffer_t const*
+    TrackJobBase::c_buffer_t const*
     TrackJobBase::ptrCBeamElementsBuffer() const SIXTRL_NOEXCEPT
     {
         SIXTRL_ASSERT(
@@ -390,12 +628,12 @@ namespace SIXTRL_CXX_NAMESPACE
 
     /* --------------------------------------------------------------------- */
 
-    SIXTRL_HOST_FN bool TrackJobBase::hasOutputBuffer() const SIXTRL_NOEXCEPT
+    bool TrackJobBase::hasOutputBuffer() const SIXTRL_NOEXCEPT
     {
         return ( this->ptrCOutputBuffer() != nullptr );
     }
 
-    SIXTRL_HOST_FN bool TrackJobBase::ownsOutputBuffer() const SIXTRL_NOEXCEPT
+    bool TrackJobBase::ownsOutputBuffer() const SIXTRL_NOEXCEPT
     {
         SIXTRL_ASSERT(
             ( this->m_my_output_buffer.get() == nullptr ) ||
@@ -408,13 +646,13 @@ namespace SIXTRL_CXX_NAMESPACE
                  ( this->m_my_output_buffer.get() != nullptr ) );
     }
 
-    SIXTRL_HOST_FN bool
+    bool
     TrackJobBase::hasElemByElemOutput() const SIXTRL_NOEXCEPT
     {
         return this->m_has_elem_by_elem_output;
     }
 
-    SIXTRL_HOST_FN bool
+    bool
     TrackJobBase::hasBeamMonitorOutput() const SIXTRL_NOEXCEPT
     {
         SIXTRL_ASSERT(
@@ -425,7 +663,7 @@ namespace SIXTRL_CXX_NAMESPACE
         return this->m_has_beam_monitor_output;
     }
 
-    SIXTRL_HOST_FN TrackJobBase::size_type
+    TrackJobBase::size_type
     TrackJobBase::beamMonitorsOutputBufferOffset() const SIXTRL_NOEXCEPT
     {
         SIXTRL_ASSERT(
@@ -438,7 +676,7 @@ namespace SIXTRL_CXX_NAMESPACE
         return this->m_be_mon_output_buffer_offset;
     }
 
-    SIXTRL_HOST_FN TrackJobBase::size_type
+    TrackJobBase::size_type
     TrackJobBase::elemByElemOutputBufferOffset() const SIXTRL_NOEXCEPT
     {
         SIXTRL_ASSERT(
@@ -451,13 +689,13 @@ namespace SIXTRL_CXX_NAMESPACE
         return this->m_elem_by_elem_output_offset;
     }
 
-    SIXTRL_HOST_FN TrackJobBase::particle_index_t
+    TrackJobBase::particle_index_t
     TrackJobBase::untilTurnElemByElem() const SIXTRL_NOEXCEPT
     {
         return this->m_until_turn_elem_by_elem;
     }
 
-    SIXTRL_HOST_FN TrackJobBase::size_type
+    TrackJobBase::size_type
     TrackJobBase::numElemByElemTurns() const SIXTRL_NOEXCEPT
     {
         using index_t = TrackJobBase::particle_index_t;
@@ -473,7 +711,7 @@ namespace SIXTRL_CXX_NAMESPACE
         return size_t{ 0 };
     }
 
-    SIXTRL_HOST_FN TrackJobBase::buffer_t*
+    TrackJobBase::buffer_t*
     TrackJobBase::ptrOutputBuffer() SIXTRL_RESTRICT
     {
         using _this_t = TrackJobBase;
@@ -483,7 +721,7 @@ namespace SIXTRL_CXX_NAMESPACE
             *this ).ptrOutputBuffer() );
     }
 
-    SIXTRL_HOST_FN TrackJobBase::buffer_t*
+    TrackJobBase::buffer_t*
     TrackJobBase::ptrOutputBuffer() const SIXTRL_RESTRICT
     {
         SIXTRL_ASSERT(
@@ -494,7 +732,7 @@ namespace SIXTRL_CXX_NAMESPACE
         return this->m_ptr_output_buffer;
     }
 
-    SIXTRL_HOST_FN TrackJobBase::c_buffer_t*
+    TrackJobBase::c_buffer_t*
     TrackJobBase::ptrCOutputBuffer() SIXTRL_RESTRICT
     {
         using _this_t = TrackJobBase;
@@ -504,7 +742,7 @@ namespace SIXTRL_CXX_NAMESPACE
             *this ).ptrCOutputBuffer() );
     }
 
-    SIXTRL_HOST_FN TrackJobBase::c_buffer_t const*
+    TrackJobBase::c_buffer_t const*
     TrackJobBase::ptrCOutputBuffer() const SIXTRL_RESTRICT
     {
         SIXTRL_ASSERT(
@@ -517,25 +755,25 @@ namespace SIXTRL_CXX_NAMESPACE
 
     /* --------------------------------------------------------------------- */
 
-    SIXTRL_HOST_FN bool TrackJobBase::hasBeamMonitors() const SIXTRL_NOEXCEPT
+    bool TrackJobBase::hasBeamMonitors() const SIXTRL_NOEXCEPT
     {
         return !this->m_beam_monitor_indices.empty();
     }
 
-    SIXTRL_HOST_FN TrackJobBase::size_type
+    TrackJobBase::size_type
     TrackJobBase::numBeamMonitors() const SIXTRL_NOEXCEPT
     {
         return this->m_beam_monitor_indices.size();
     }
 
 
-    SIXTRL_HOST_FN TrackJobBase::size_type const*
+    TrackJobBase::size_type const*
     TrackJobBase::beamMonitorIndicesBegin() const SIXTRL_NOEXCEPT
     {
         return this->m_beam_monitor_indices.data();
     }
 
-    SIXTRL_HOST_FN TrackJobBase::size_type const*
+    TrackJobBase::size_type const*
     TrackJobBase::beamMonitorIndicesEnd() const SIXTRL_NOEXCEPT
     {
         TrackJobBase::size_type const* end_ptr =
@@ -549,7 +787,7 @@ namespace SIXTRL_CXX_NAMESPACE
         return end_ptr;
     }
 
-    SIXTRL_HOST_FN TrackJobBase::size_type
+    TrackJobBase::size_type
     TrackJobBase::beamMonitorIndex( TrackJobBase::size_type const n ) const
     {
         return this->m_beam_monitor_indices.at( n );
@@ -557,7 +795,7 @@ namespace SIXTRL_CXX_NAMESPACE
 
     /* --------------------------------------------------------------------- */
 
-    SIXTRL_HOST_FN bool
+    bool
     TrackJobBase::hasElemByElemConfig() const SIXTRL_NOEXCEPT
     {
         SIXTRL_ASSERT(
@@ -568,7 +806,7 @@ namespace SIXTRL_CXX_NAMESPACE
             this->m_my_elem_by_elem_config.get() ) );
     }
 
-    SIXTRL_HOST_FN TrackJobBase::elem_by_elem_config_t*
+    TrackJobBase::elem_by_elem_config_t*
     TrackJobBase::ptrElemByElemConfig() SIXTRL_NOEXCEPT
     {
         using _this_t = TrackJobBase;
@@ -578,46 +816,46 @@ namespace SIXTRL_CXX_NAMESPACE
             *this ).ptrElemByElemConfig() );
     }
 
-    SIXTRL_HOST_FN TrackJobBase::elem_by_elem_order_t
+    TrackJobBase::elem_by_elem_order_t
     TrackJobBase::elemByElemOrder() const SIXTRL_NOEXCEPT
     {
         return ::NS(ElemByElemConfig_get_order)(
             this->m_my_elem_by_elem_config.get() );
     }
 
-    SIXTRL_HOST_FN TrackJobBase::elem_by_elem_order_t
+    TrackJobBase::elem_by_elem_order_t
     TrackJobBase::defaultElemByElemOrder() const SIXTRL_NOEXCEPT
     {
         return this->m_default_elem_by_elem_order;
     }
 
-    SIXTRL_HOST_FN void TrackJobBase::setDefaultElemByElemOrder(
+    void TrackJobBase::setDefaultElemByElemOrder(
         TrackJobBase::elem_by_elem_order_t const order ) SIXTRL_NOEXCEPT
     {
         this->m_default_elem_by_elem_order = order;
         return;
     }
 
-    SIXTRL_HOST_FN TrackJobBase::elem_by_elem_config_t const*
+    TrackJobBase::elem_by_elem_config_t const*
     TrackJobBase::ptrElemByElemConfig() const SIXTRL_NOEXCEPT
     {
         return this->m_my_elem_by_elem_config.get();
     }
 
-    SIXTRL_HOST_FN bool
+    bool
     TrackJobBase::elemByElemRolling() const SIXTRL_NOEXCEPT
     {
         return ::NS(ElemByElemConfig_is_rolling)(
             this->ptrElemByElemConfig() );
     }
 
-    SIXTRL_HOST_FN bool
+    bool
     TrackJobBase::defaultElemByElemRolling() const SIXTRL_NOEXCEPT
     {
         return this->m_default_elem_by_elem_rolling;
     }
 
-    SIXTRL_HOST_FN void TrackJobBase::setDefaultElemByElemRolling(
+    void TrackJobBase::setDefaultElemByElemRolling(
         bool is_rolling ) SIXTRL_NOEXCEPT
     {
         this->m_default_elem_by_elem_rolling = is_rolling;
@@ -626,7 +864,7 @@ namespace SIXTRL_CXX_NAMESPACE
 
     /* --------------------------------------------------------------------- */
 
-    SIXTRL_HOST_FN TrackJobBase::TrackJobBase(
+    TrackJobBase::TrackJobBase(
         const char *const SIXTRL_RESTRICT type_str,
         track_job_type_t const type_id ) :
         m_type_str(),
@@ -653,6 +891,9 @@ namespace SIXTRL_CXX_NAMESPACE
         m_min_initial_turn_id( TrackJobBase::particle_index_t{ 0 } ),
         m_max_initial_turn_id( TrackJobBase::particle_index_t{ 0 } ),
         m_until_turn_elem_by_elem( TrackJobBase::size_type{ 0 } ),
+        m_collect_flags(
+            SIXTRL_CXX_NAMESPACE::TRACK_JOB_COLLECT_DEFAULT_FLAGS ),
+        m_requires_collect( true ),
         m_default_elem_by_elem_rolling( true ),
         m_has_beam_monitor_output( false ),
         m_has_elem_by_elem_output( false )
@@ -666,7 +907,7 @@ namespace SIXTRL_CXX_NAMESPACE
         this->doInitDefaultBeamMonitorIndices();
     }
 
-    SIXTRL_HOST_FN TrackJobBase::TrackJobBase( TrackJobBase const& other ) :
+    TrackJobBase::TrackJobBase( TrackJobBase const& other ) :
         m_type_str( other.m_type_str ),
         m_device_id_str( other.m_type_str ),
         m_config_str( other.m_config_str ),
@@ -691,6 +932,8 @@ namespace SIXTRL_CXX_NAMESPACE
         m_min_initial_turn_id( other.m_min_initial_turn_id ),
         m_max_initial_turn_id( other.m_max_initial_turn_id ),
         m_until_turn_elem_by_elem( other.m_until_turn_elem_by_elem ),
+        m_collect_flags( other.m_collect_flags ),
+        m_requires_collect( other.m_requires_collect ),
         m_default_elem_by_elem_rolling( other.m_default_elem_by_elem_rolling ),
         m_has_beam_monitor_output( other.m_has_beam_monitor_output ),
         m_has_elem_by_elem_output( other.m_has_elem_by_elem_output )
@@ -711,7 +954,7 @@ namespace SIXTRL_CXX_NAMESPACE
         }
     }
 
-    SIXTRL_HOST_FN TrackJobBase::TrackJobBase(
+    TrackJobBase::TrackJobBase(
         TrackJobBase&& o ) SIXTRL_NOEXCEPT :
         m_type_str( std::move( o.m_type_str ) ),
         m_device_id_str( std::move( o.m_type_str ) ),
@@ -740,6 +983,8 @@ namespace SIXTRL_CXX_NAMESPACE
         m_min_initial_turn_id( std::move( o.m_min_initial_turn_id ) ),
         m_max_initial_turn_id( std::move( o.m_max_initial_turn_id ) ),
         m_until_turn_elem_by_elem( std::move( o.m_until_turn_elem_by_elem ) ),
+        m_collect_flags( std::move( o.m_collect_flags ) ),
+        m_requires_collect( std::move( o.m_requires_collect ) ),
         m_default_elem_by_elem_rolling( std::move(
             o.m_default_elem_by_elem_rolling ) ),
         m_has_beam_monitor_output( std::move( o.m_has_beam_monitor_output ) ),
@@ -752,7 +997,7 @@ namespace SIXTRL_CXX_NAMESPACE
         o.doClearBaseImpl();
     }
 
-    SIXTRL_HOST_FN TrackJobBase& TrackJobBase::operator=(
+    TrackJobBase& TrackJobBase::operator=(
         TrackJobBase const& rhs )
     {
         if( this != &rhs )
@@ -791,6 +1036,8 @@ namespace SIXTRL_CXX_NAMESPACE
 
             this->m_has_beam_monitor_output = rhs.m_has_beam_monitor_output;
             this->m_has_elem_by_elem_output = rhs.m_has_elem_by_elem_output;
+            this->m_requires_collect        = rhs.m_requires_collect;
+            this->m_collect_flags           = rhs.m_collect_flags;
 
             if( rhs.ownsOutputBuffer() )
             {
@@ -819,7 +1066,7 @@ namespace SIXTRL_CXX_NAMESPACE
         return *this;
     }
 
-    SIXTRL_HOST_FN TrackJobBase& TrackJobBase::operator=(
+    TrackJobBase& TrackJobBase::operator=(
         TrackJobBase&& rhs ) SIXTRL_NOEXCEPT
     {
         if( this != &rhs )
@@ -875,6 +1122,9 @@ namespace SIXTRL_CXX_NAMESPACE
             this->m_until_turn_elem_by_elem =
                 std::move( rhs.m_until_turn_elem_by_elem );
 
+            this->m_requires_collect = std::move( rhs.m_requires_collect );
+            this->m_collect_flags = std::move( rhs.m_collect_flags );
+
             this->m_default_elem_by_elem_rolling =
                 std::move( rhs.m_default_elem_by_elem_rolling );
 
@@ -897,30 +1147,30 @@ namespace SIXTRL_CXX_NAMESPACE
 
     /* --------------------------------------------------------------------- */
 
-    SIXTRL_HOST_FN void TrackJobBase::doClear()
+    void TrackJobBase::doClear()
     {
         this->doClearBaseImpl();
         return;
     }
 
-    SIXTRL_HOST_FN void TrackJobBase::doCollect()
+    void TrackJobBase::doCollect( collect_flag_t const )
     {
         return;
     }
 
-    SIXTRL_HOST_FN TrackJobBase::track_status_t
+    TrackJobBase::track_status_t
     TrackJobBase::doTrackUntilTurn( size_type const )
     {
         return TrackJobBase::track_status_t{ -1 };
     }
 
-    SIXTRL_HOST_FN TrackJobBase::track_status_t
+    TrackJobBase::track_status_t
     TrackJobBase::doTrackElemByElem( size_type const )
     {
         return TrackJobBase::track_status_t{ -1 };
     }
 
-    SIXTRL_HOST_FN TrackJobBase::track_status_t
+    TrackJobBase::track_status_t
     TrackJobBase::doTrackLine( size_type const, size_type const, bool const )
     {
         return TrackJobBase::track_status_t{ -1 };
@@ -928,7 +1178,7 @@ namespace SIXTRL_CXX_NAMESPACE
 
     /* --------------------------------------------------------------------- */
 
-    SIXTRL_HOST_FN bool TrackJobBase::doPrepareParticlesStructures(
+    bool TrackJobBase::doPrepareParticlesStructures(
         TrackJobBase::c_buffer_t* SIXTRL_RESTRICT pb )
     {
         bool success = false;
@@ -987,7 +1237,7 @@ namespace SIXTRL_CXX_NAMESPACE
         return success;
     }
 
-    SIXTRL_HOST_FN bool TrackJobBase::doPrepareBeamElementsStructures(
+    bool TrackJobBase::doPrepareBeamElementsStructures(
         TrackJobBase::c_buffer_t* SIXTRL_RESTRICT belems )
     {
         bool success = false;
@@ -1080,7 +1330,7 @@ namespace SIXTRL_CXX_NAMESPACE
         return success;
     }
 
-    SIXTRL_HOST_FN bool TrackJobBase::doPrepareOutputStructures(
+    bool TrackJobBase::doPrepareOutputStructures(
         TrackJobBase::c_buffer_t* SIXTRL_RESTRICT particles_buffer,
         TrackJobBase::c_buffer_t* SIXTRL_RESTRICT beam_elements_buffer,
         TrackJobBase::c_buffer_t* SIXTRL_RESTRICT ptr_output_buffer,
@@ -1300,7 +1550,7 @@ namespace SIXTRL_CXX_NAMESPACE
         return success;
     }
 
-    SIXTRL_HOST_FN bool TrackJobBase::doReset(
+    bool TrackJobBase::doReset(
         TrackJobBase::c_buffer_t* SIXTRL_RESTRICT particles_buffer,
         TrackJobBase::c_buffer_t* SIXTRL_RESTRICT beam_elem_buffer,
         TrackJobBase::c_buffer_t* SIXTRL_RESTRICT output_buffer,
@@ -1341,7 +1591,7 @@ namespace SIXTRL_CXX_NAMESPACE
         return success;
     }
 
-    SIXTRL_HOST_FN bool TrackJobBase::doAssignNewOutputBuffer(
+    bool TrackJobBase::doAssignNewOutputBuffer(
         TrackJobBase::c_buffer_t* SIXTRL_RESTRICT ptr_output_buffer )
     {
         bool success = false;
@@ -1378,14 +1628,14 @@ namespace SIXTRL_CXX_NAMESPACE
 
     /* --------------------------------------------------------------------- */
 
-    SIXTRL_HOST_FN void TrackJobBase::doParseConfigStr(
+    void TrackJobBase::doParseConfigStr(
         const char *const SIXTRL_RESTRICT config_str )
     {
         this->doParseConfigStrBaseImpl( config_str );
         return;
     }
 
-    SIXTRL_HOST_FN void TrackJobBase::doSetDeviceIdStr(
+    void TrackJobBase::doSetDeviceIdStr(
         const char *const SIXTRL_RESTRICT device_id_str )
     {
         if( device_id_str != nullptr )
@@ -1400,7 +1650,7 @@ namespace SIXTRL_CXX_NAMESPACE
         return;
     }
 
-    SIXTRL_HOST_FN void TrackJobBase::doSetConfigStr(
+    void TrackJobBase::doSetConfigStr(
         const char *const SIXTRL_RESTRICT config_str )
     {
         if( config_str != nullptr )
@@ -1415,7 +1665,7 @@ namespace SIXTRL_CXX_NAMESPACE
         return;
     }
 
-    SIXTRL_HOST_FN void TrackJobBase::doSetPtrParticleBuffer(
+    void TrackJobBase::doSetPtrParticleBuffer(
         TrackJobBase::buffer_t* SIXTRL_RESTRICT ptr_buffer ) SIXTRL_NOEXCEPT
     {
         if( ptr_buffer != nullptr )
@@ -1433,7 +1683,7 @@ namespace SIXTRL_CXX_NAMESPACE
         return;
     }
 
-    SIXTRL_HOST_FN void TrackJobBase::doSetPtrCParticleBuffer(
+    void TrackJobBase::doSetPtrCParticleBuffer(
         TrackJobBase::c_buffer_t* SIXTRL_RESTRICT ptr_buffer ) SIXTRL_NOEXCEPT
     {
         if( ( this->m_ptr_particles_buffer   != nullptr ) &&
@@ -1448,7 +1698,7 @@ namespace SIXTRL_CXX_NAMESPACE
         return;
     }
 
-    SIXTRL_HOST_FN void TrackJobBase::doSetPtrBeamElementsBuffer(
+    void TrackJobBase::doSetPtrBeamElementsBuffer(
         TrackJobBase::buffer_t* SIXTRL_RESTRICT ptr_buffer ) SIXTRL_NOEXCEPT
     {
         if( ptr_buffer != nullptr )
@@ -1466,7 +1716,7 @@ namespace SIXTRL_CXX_NAMESPACE
         return;
     }
 
-    SIXTRL_HOST_FN void TrackJobBase::doSetPtrCBeamElementsBuffer(
+    void TrackJobBase::doSetPtrCBeamElementsBuffer(
         TrackJobBase::c_buffer_t* SIXTRL_RESTRICT ptr_buffer ) SIXTRL_NOEXCEPT
     {
         if( ( this->m_ptr_beam_elem_buffer != nullptr ) &&
@@ -1481,7 +1731,7 @@ namespace SIXTRL_CXX_NAMESPACE
         return;
     }
 
-    SIXTRL_HOST_FN void TrackJobBase::doSetPtrOutputBuffer(
+    void TrackJobBase::doSetPtrOutputBuffer(
         TrackJobBase::buffer_t* SIXTRL_RESTRICT ptr_buffer ) SIXTRL_NOEXCEPT
     {
         if( ptr_buffer != nullptr )
@@ -1499,7 +1749,7 @@ namespace SIXTRL_CXX_NAMESPACE
         return;
     }
 
-    SIXTRL_HOST_FN void TrackJobBase::doSetPtrCOutputBuffer(
+    void TrackJobBase::doSetPtrCOutputBuffer(
         TrackJobBase::c_buffer_t* SIXTRL_RESTRICT ptr_buffer ) SIXTRL_NOEXCEPT
     {
         if( ( this->m_ptr_output_buffer != nullptr ) &&
@@ -1514,14 +1764,14 @@ namespace SIXTRL_CXX_NAMESPACE
         return;
     }
 
-    SIXTRL_HOST_FN void TrackJobBase::doSetBeamMonitorOutputBufferOffset(
+    void TrackJobBase::doSetBeamMonitorOutputBufferOffset(
         TrackJobBase::size_type const output_buffer_offset ) SIXTRL_NOEXCEPT
     {
         this->m_be_mon_output_buffer_offset = output_buffer_offset;
         return;
     }
 
-    SIXTRL_HOST_FN void TrackJobBase::doSetUntilTurnElemByElem(
+    void TrackJobBase::doSetUntilTurnElemByElem(
         TrackJobBase::particle_index_t const
             until_turn_elem_by_elem ) SIXTRL_NOEXCEPT
     {
@@ -1529,28 +1779,35 @@ namespace SIXTRL_CXX_NAMESPACE
         return;
     }
 
-    SIXTRL_HOST_FN void TrackJobBase::doSetElemByElemOutputIndexOffset(
+    void TrackJobBase::doSetElemByElemOutputIndexOffset(
         TrackJobBase::size_type const elem_by_elem_output_offset ) SIXTRL_NOEXCEPT
     {
         this->m_elem_by_elem_output_offset = elem_by_elem_output_offset;
         return;
     }
 
-    SIXTRL_HOST_FN void TrackJobBase::doSetBeamMonitorOutputEnabledFlag(
+    void TrackJobBase::doSetRequiresCollectFlag(
+        bool const requires_collect_flag ) SIXTRL_NOEXCEPT
+    {
+        this->m_requires_collect = requires_collect_flag;
+        return;
+    }
+
+    void TrackJobBase::doSetBeamMonitorOutputEnabledFlag(
         bool const has_beam_monitor_output ) SIXTRL_NOEXCEPT
     {
         this->m_has_beam_monitor_output = has_beam_monitor_output;
         return;
     }
 
-    SIXTRL_HOST_FN void TrackJobBase::doSetElemByElemOutputEnabledFlag(
+    void TrackJobBase::doSetElemByElemOutputEnabledFlag(
         bool const elem_by_elem_flag ) SIXTRL_NOEXCEPT
     {
         this->m_has_elem_by_elem_output = elem_by_elem_flag;
         return;
     }
 
-    SIXTRL_HOST_FN void TrackJobBase::doInitDefaultParticleSetIndices()
+    void TrackJobBase::doInitDefaultParticleSetIndices()
     {
         this->m_particle_set_indices.clear();
         this->m_particle_set_indices.push_back( TrackJobBase::size_type{ 0 } );
@@ -1558,53 +1815,53 @@ namespace SIXTRL_CXX_NAMESPACE
         return;
     }
 
-    SIXTRL_HOST_FN void TrackJobBase::doInitDefaultBeamMonitorIndices()
+    void TrackJobBase::doInitDefaultBeamMonitorIndices()
     {
         this->m_beam_monitor_indices.clear();
         return;
     }
 
-    SIXTRL_HOST_FN void TrackJobBase::doSetMinParticleId(
+    void TrackJobBase::doSetMinParticleId(
         TrackJobBase::particle_index_t const min_particle_id ) SIXTRL_NOEXCEPT
     {
         this->m_min_particle_id = min_particle_id;
     }
 
-    SIXTRL_HOST_FN void TrackJobBase::doSetMaxParticleId(
+    void TrackJobBase::doSetMaxParticleId(
         TrackJobBase::particle_index_t const max_particle_id ) SIXTRL_NOEXCEPT
     {
         this->m_max_particle_id = max_particle_id;
     }
 
-    SIXTRL_HOST_FN void TrackJobBase::doSetMinElementId(
+    void TrackJobBase::doSetMinElementId(
         TrackJobBase::particle_index_t const min_element_id ) SIXTRL_NOEXCEPT
     {
         this->m_min_element_id = min_element_id;
         return;
     }
 
-    SIXTRL_HOST_FN void TrackJobBase::doSetMaxElementId(
+    void TrackJobBase::doSetMaxElementId(
         TrackJobBase::particle_index_t const max_element_id ) SIXTRL_NOEXCEPT
     {
         this->m_max_element_id = max_element_id;
         return;
     }
 
-    SIXTRL_HOST_FN void TrackJobBase::doSetMinInitialTurnId(
+    void TrackJobBase::doSetMinInitialTurnId(
         TrackJobBase::particle_index_t const min_turn_id ) SIXTRL_NOEXCEPT
     {
         this->m_min_initial_turn_id = min_turn_id;
         return;
     }
 
-    SIXTRL_HOST_FN void TrackJobBase::doSetMaxInitialTurnId(
+    void TrackJobBase::doSetMaxInitialTurnId(
         TrackJobBase::particle_index_t const max_turn_id ) SIXTRL_NOEXCEPT
     {
         this->m_max_initial_turn_id = max_turn_id;
         return;
     }
 
-    SIXTRL_HOST_FN void TrackJobBase::doUpdateStoredOutputBuffer(
+    void TrackJobBase::doUpdateStoredOutputBuffer(
         TrackJobBase::ptr_output_buffer_t&& ptr_output_buffer ) SIXTRL_NOEXCEPT
     {
         this->doSetPtrOutputBuffer( ptr_output_buffer.get() );
@@ -1612,14 +1869,14 @@ namespace SIXTRL_CXX_NAMESPACE
         return;
     }
 
-    SIXTRL_HOST_FN void TrackJobBase::doUpdateStoredElemByElemConfig(
+    void TrackJobBase::doUpdateStoredElemByElemConfig(
         TrackJobBase::ptr_elem_by_elem_config_t&& ptr_config ) SIXTRL_NOEXCEPT
     {
         this->m_my_elem_by_elem_config = std::move( ptr_config );
         return;
     }
 
-    SIXTRL_HOST_FN void TrackJobBase::doClearBaseImpl() SIXTRL_NOEXCEPT
+    void TrackJobBase::doClearBaseImpl() SIXTRL_NOEXCEPT
     {
         this->doInitDefaultParticleSetIndices();
         this->doInitDefaultBeamMonitorIndices();
@@ -1654,7 +1911,7 @@ namespace SIXTRL_CXX_NAMESPACE
         return;
     }
 
-    SIXTRL_HOST_FN void TrackJobBase::doParseConfigStrBaseImpl(
+    void TrackJobBase::doParseConfigStrBaseImpl(
         const char *const SIXTRL_RESTRICT config_str )
     {
         ( void )config_str;

--- a/sixtracklib/common/internal/track_job_base.h
+++ b/sixtracklib/common/internal/track_job_base.h
@@ -19,43 +19,86 @@
 #endif /* !defined( SIXTRL_NO_SYSTEM_INCLUDES ) */
 
 #if !defined( SIXTRL_NO_INCLUDES )
+    #include "sixtracklib/common/definitions.h"
+    #include "sixtracklib/common/track/definitions.h"
+
     #if defined( __cplusplus )
         #include "sixtracklib/common/buffer.hpp"
     #endif /* defined( __cplusplus ) */
 
     #include "sixtracklib/common/buffer.h"
-    #include "sixtracklib/common/definitions.h"
     #include "sixtracklib/common/particles.h"
     #include "sixtracklib/common/output/output_buffer.h"
     #include "sixtracklib/common/output/elem_by_elem_config.h"
 #endif /* !defined( SIXTRL_NO_INCLUDES ) */
 
-typedef SIXTRL_INT64_T  NS(track_job_type_t);
-typedef SIXTRL_INT32_T  NS(track_status_t);
-
 #if defined( __cplusplus ) && !defined( _GPUCODE )
 
 namespace SIXTRL_CXX_NAMESPACE
 {
-    using track_job_type_t        = ::NS(track_job_type_t);
-    using track_status_t          = ::NS(track_status_t);
-
     class TrackJobBase
     {
         public:
 
-        using buffer_t                = Buffer;
-        using c_buffer_t              = ::NS(Buffer);
-        using elem_by_elem_config_t   = ::NS(ElemByElemConfig);
-        using elem_by_elem_order_t    = ::NS(elem_by_elem_order_t);
-        using particle_index_t        = ::NS(particle_index_t);
-        using size_type               = Buffer::size_type;
-        using type_t                  = SIXTRL_CXX_NAMESPACE::track_job_type_t;
-        using track_status_t          = SIXTRL_CXX_NAMESPACE::track_status_t;
-        using output_buffer_flag_t    = ::NS(output_buffer_flag_t);
+        using buffer_t              = Buffer;
+        using c_buffer_t            = ::NS(Buffer);
+        using elem_by_elem_config_t = ::NS(ElemByElemConfig);
+        using elem_by_elem_order_t  = ::NS(elem_by_elem_order_t);
+        using particle_index_t      = ::NS(particle_index_t);
+        using size_type             = SIXTRL_CXX_NAMESPACE::track_job_size_t;
+        using type_t                = SIXTRL_CXX_NAMESPACE::track_job_type_t;
+        using track_status_t        = SIXTRL_CXX_NAMESPACE::track_status_t;
+        using output_buffer_flag_t  = ::NS(output_buffer_flag_t);
+
+        using collect_flag_t = SIXTRL_CXX_NAMESPACE::track_job_collect_flag_t;
+
+        /* ----------------------------------------------------------------- */
+
+        SIXTRL_HOST_FN static bool IsCollectFlagSet(
+            collect_flag_t const haystack,
+            collect_flag_t const needle ) SIXTRL_NOEXCEPT;
+
+        SIXTRL_HOST_FN static size_type
+        DefaultNumParticleSetIndices() SIXTRL_NOEXCEPT;
+
+        SIXTRL_HOST_FN static size_type const*
+        DefaultParticleSetIndicesBegin() SIXTRL_NOEXCEPT;
+
+        SIXTRL_HOST_FN static size_type const*
+        DefaultParticleSetIndicesEnd() SIXTRL_NOEXCEPT;
+
+        /* ----------------------------------------------------------------- */
 
         SIXTRL_HOST_FN void clear();
+
+        /* ----------------------------------------------------------------- */
+
         SIXTRL_HOST_FN void collect();
+        SIXTRL_HOST_FN void collect( collect_flag_t const flags );
+
+        SIXTRL_HOST_FN void collectParticles();
+        SIXTRL_HOST_FN void collectBeamElements();
+        SIXTRL_HOST_FN void collectOutput();
+
+        SIXTRL_HOST_FN void enableCollectParticles()  SIXTRL_NOEXCEPT;
+        SIXTRL_HOST_FN void disableCollectParticles() SIXTRL_NOEXCEPT;
+        SIXTRL_HOST_FN bool isCollectingParticles() const SIXTRL_NOEXCEPT;
+
+        SIXTRL_HOST_FN void enableCollectBeamElements()  SIXTRL_NOEXCEPT;
+        SIXTRL_HOST_FN void disableCollectBeamElements() SIXTRL_NOEXCEPT;
+        SIXTRL_HOST_FN bool isCollectingBeamElements() const SIXTRL_NOEXCEPT;
+
+        SIXTRL_HOST_FN void enableCollectOutput()  SIXTRL_NOEXCEPT;
+        SIXTRL_HOST_FN void disableCollectOutput() SIXTRL_NOEXCEPT;
+        SIXTRL_HOST_FN bool isCollectingOutput() const SIXTRL_NOEXCEPT;
+
+        SIXTRL_HOST_FN collect_flag_t collectFlags() const SIXTRL_NOEXCEPT;
+        SIXTRL_HOST_FN void setCollectFlags(
+            collect_flag_t const flag ) SIXTRL_NOEXCEPT;
+
+        SIXTRL_HOST_FN bool requiresCollecting() const SIXTRL_NOEXCEPT;
+
+        /* ----------------------------------------------------------------- */
 
         SIXTRL_HOST_FN track_status_t track(
             size_type const until_turn );
@@ -80,6 +123,12 @@ namespace SIXTRL_CXX_NAMESPACE
             buffer_t* SIXTRL_RESTRICT ptr_output_buffer   = nullptr,
             size_type const until_turn_elem_by_elem = size_type{ 0 } );
 
+        SIXTRL_HOST_FN bool reset(
+            buffer_t& SIXTRL_RESTRICT_REF particles_buffer,
+            size_type const particle_set_index,
+            buffer_t& SIXTRL_RESTRICT_REF beam_elements_buffer,
+            buffer_t* SIXTRL_RESTRICT ptr_output_buffer = nullptr,
+            size_type const until_turn_elem_by_elem = size_type{ 0 } );
 
         template< typename ParSetIndexIter  >
         SIXTRL_HOST_FN bool reset(
@@ -92,6 +141,13 @@ namespace SIXTRL_CXX_NAMESPACE
 
         SIXTRL_HOST_FN bool reset(
             c_buffer_t* SIXTRL_RESTRICT particles_buffer,
+            c_buffer_t* SIXTRL_RESTRICT beam_elements_buffer,
+            c_buffer_t* SIXTRL_RESTRICT ptr_output_buffer = nullptr,
+            size_type const until_turn_elem_by_elem = size_type{ 0 } );
+
+        SIXTRL_HOST_FN bool reset(
+            c_buffer_t* SIXTRL_RESTRICT particles_buffer,
+            size_type const particle_set_index,
             c_buffer_t* SIXTRL_RESTRICT beam_elements_buffer,
             c_buffer_t* SIXTRL_RESTRICT ptr_output_buffer = nullptr,
             size_type const until_turn_elem_by_elem = size_type{ 0 } );
@@ -112,6 +168,9 @@ namespace SIXTRL_CXX_NAMESPACE
             c_buffer_t* SIXTRL_RESTRICT beam_elements_buffer,
             c_buffer_t* SIXTRL_RESTRICT ptr_output_buffer = nullptr,
             size_type const until_turn_elem_by_elem = size_type{ 0 } );
+
+        SIXTRL_HOST_FN bool selectParticleSet(
+            size_type const particle_set_index );
 
         SIXTRL_HOST_FN bool assignOutputBuffer(
             buffer_t& SIXTRL_RESTRICT_REF output_buffer );
@@ -197,8 +256,8 @@ namespace SIXTRL_CXX_NAMESPACE
         SIXTRL_HOST_FN particle_index_t
         untilTurnElemByElem() const SIXTRL_NOEXCEPT;
 
-        SIXTRL_HOST_FN size_type numElemByElemTurns()  const SIXTRL_NOEXCEPT;
-//
+        SIXTRL_HOST_FN size_type numElemByElemTurns() const SIXTRL_NOEXCEPT;
+
         SIXTRL_HOST_FN buffer_t* ptrOutputBuffer() SIXTRL_RESTRICT;
         SIXTRL_HOST_FN buffer_t* ptrOutputBuffer() const SIXTRL_RESTRICT;
 
@@ -255,6 +314,10 @@ namespace SIXTRL_CXX_NAMESPACE
         using ptr_elem_by_elem_config_t =
             std::unique_ptr< elem_by_elem_config_t >;
 
+        SIXTRL_HOST_FN static collect_flag_t UnsetCollectFlag(
+            collect_flag_t const haystack,
+            collect_flag_t const needle ) SIXTRL_NOEXCEPT;
+
         SIXTRL_HOST_FN TrackJobBase(
             const char *const SIXTRL_RESTRICT type_str,
             track_job_type_t const type_id );
@@ -270,7 +333,7 @@ namespace SIXTRL_CXX_NAMESPACE
 
         SIXTRL_HOST_FN virtual void doClear();
 
-        SIXTRL_HOST_FN virtual void doCollect();
+        SIXTRL_HOST_FN virtual void doCollect( collect_flag_t const flags );
 
         /* ----------------------------------------------------------------- */
 
@@ -348,6 +411,9 @@ namespace SIXTRL_CXX_NAMESPACE
 
         SIXTRL_HOST_FN void doSetUntilTurnElemByElem(
             particle_index_t const until_turn_elem_by_elem ) SIXTRL_NOEXCEPT;
+
+        SIXTRL_HOST_FN void doSetRequiresCollectFlag(
+            bool const requires_collect_flag ) SIXTRL_NOEXCEPT;
 
         SIXTRL_HOST_FN void doSetBeamMonitorOutputEnabledFlag(
             bool const beam_monitor_flag ) SIXTRL_NOEXCEPT;
@@ -432,6 +498,8 @@ namespace SIXTRL_CXX_NAMESPACE
         particle_index_t                m_max_initial_turn_id;
         particle_index_t                m_until_turn_elem_by_elem;
 
+        collect_flag_t                  m_collect_flags;
+        bool                            m_requires_collect;
         bool                            m_default_elem_by_elem_rolling;
         bool                            m_has_beam_monitor_output;
         bool                            m_has_elem_by_elem_output;
@@ -632,6 +700,23 @@ namespace SIXTRL_CXX_NAMESPACE
         }
 
         return;
+    }
+
+    /* --------------------------------------------------------------------- */
+
+    SIXTRL_INLINE bool TrackJobBase::IsCollectFlagSet(
+        TrackJobBase::collect_flag_t const flag_set,
+        TrackJobBase::collect_flag_t const flag ) SIXTRL_NOEXCEPT
+    {
+        return ( ( flag_set & flag ) == flag );
+    }
+
+    SIXTRL_INLINE TrackJobBase::collect_flag_t
+    TrackJobBase::UnsetCollectFlag(
+        TrackJobBase::collect_flag_t const flag_set,
+        TrackJobBase::collect_flag_t const flag ) SIXTRL_NOEXCEPT
+    {
+        return flag_set & ~flag;
     }
 }
 

--- a/sixtracklib/common/internal/track_job_cpu.cpp
+++ b/sixtracklib/common/internal/track_job_cpu.cpp
@@ -18,10 +18,12 @@
 
 namespace SIXTRL_CXX_NAMESPACE
 {
-    SIXTRL_HOST_FN TrackJobCpu::TrackJobCpu( std::string const& config_str ) :
+    TrackJobCpu::TrackJobCpu( std::string const& config_str ) :
         TrackJobBase( SIXTRL_CXX_NAMESPACE::TRACK_JOB_CPU_STR,
                       SIXTRL_CXX_NAMESPACE::TRACK_JOB_CPU_ID )
     {
+        this->doSetRequiresCollectFlag( false );
+
         if( !config_str.empty() )
         {
             TrackJobBase::doSetConfigStr( config_str.c_str() );
@@ -29,11 +31,13 @@ namespace SIXTRL_CXX_NAMESPACE
         }
     }
 
-    SIXTRL_HOST_FN TrackJobCpu::TrackJobCpu(
+    TrackJobCpu::TrackJobCpu(
         const char *const SIXTRL_RESTRICT config_str ) :
         TrackJobBase( SIXTRL_CXX_NAMESPACE::TRACK_JOB_CPU_STR,
                       SIXTRL_CXX_NAMESPACE::TRACK_JOB_CPU_ID )
     {
+        this->doSetRequiresCollectFlag( false );
+
         if( ( config_str != nullptr ) &&
             ( std::strlen( config_str ) > TrackJobCpu::size_type{ 0 } ) )
         {
@@ -42,7 +46,7 @@ namespace SIXTRL_CXX_NAMESPACE
         }
     }
 
-    SIXTRL_HOST_FN TrackJobCpu::TrackJobCpu(
+    TrackJobCpu::TrackJobCpu(
         TrackJobCpu::c_buffer_t* SIXTRL_RESTRICT particles_buffer,
         TrackJobCpu::c_buffer_t* SIXTRL_RESTRICT beam_elements_buffer,
         TrackJobCpu::c_buffer_t* SIXTRL_RESTRICT ptr_output_buffer,
@@ -51,6 +55,8 @@ namespace SIXTRL_CXX_NAMESPACE
         TrackJobBase( SIXTRL_CXX_NAMESPACE::TRACK_JOB_CPU_STR,
                       SIXTRL_CXX_NAMESPACE::TRACK_JOB_CPU_ID )
     {
+        this->doSetRequiresCollectFlag( false );
+
         if( TrackJobBase::doReset( particles_buffer, beam_elements_buffer,
                 ptr_output_buffer, until_turn_elem_by_elem ) )
         {
@@ -66,10 +72,9 @@ namespace SIXTRL_CXX_NAMESPACE
         }
     }
 
-    SIXTRL_HOST_FN TrackJobCpu::TrackJobCpu(
+    TrackJobCpu::TrackJobCpu(
         TrackJobCpu::c_buffer_t* SIXTRL_RESTRICT particles_buffer,
-        TrackJobCpu::size_type const num_particle_sets,
-        TrackJobCpu::size_type const* SIXTRL_RESTRICT pset_indices_begin,
+        TrackJobCpu::size_type const particle_set_index,
         TrackJobCpu::c_buffer_t* SIXTRL_RESTRICT beam_elements_buffer,
         TrackJobCpu::c_buffer_t* SIXTRL_RESTRICT ptr_output_buffer,
         TrackJobCpu::size_type const until_turn_elem_by_elem,
@@ -79,6 +84,8 @@ namespace SIXTRL_CXX_NAMESPACE
     {
         using size_t = TrackJobCpu::size_type;
         size_t const* pset_indices_end = pset_indices_begin;
+
+        this->doSetRequiresCollectFlag( false );
 
         if( ( num_particle_sets > size_t{ 0 } ) &&
             ( pset_indices_end != nullptr ) )
@@ -103,7 +110,46 @@ namespace SIXTRL_CXX_NAMESPACE
         }
     }
 
-    SIXTRL_HOST_FN TrackJobCpu::TrackJobCpu(
+    TrackJobCpu::TrackJobCpu(
+        TrackJobCpu::c_buffer_t* SIXTRL_RESTRICT particles_buffer,
+        TrackJobCpu::size_type const num_particle_sets,
+        TrackJobCpu::size_type const* SIXTRL_RESTRICT pset_indices_begin,
+        TrackJobCpu::c_buffer_t* SIXTRL_RESTRICT beam_elements_buffer,
+        TrackJobCpu::c_buffer_t* SIXTRL_RESTRICT ptr_output_buffer,
+        TrackJobCpu::size_type const until_turn_elem_by_elem,
+        const char *const SIXTRL_RESTRICT config_str ) :
+        TrackJobBase( SIXTRL_CXX_NAMESPACE::TRACK_JOB_CPU_STR,
+                      SIXTRL_CXX_NAMESPACE::TRACK_JOB_CPU_ID )
+    {
+        using size_t = TrackJobCpu::size_type;
+        size_t const* pset_indices_end = pset_indices_begin;
+
+        this->doSetRequiresCollectFlag( false );
+
+        if( ( num_particle_sets > size_t{ 0 } ) &&
+            ( pset_indices_end != nullptr ) )
+        {
+            std::advance( pset_indices_end, num_particle_sets );
+            this->doSetParticleSetIndices( pset_indices_begin,
+                pset_indices_end, particles_buffer );
+        }
+
+        if( TrackJobBase::doReset( particles_buffer, beam_elements_buffer,
+                ptr_output_buffer, until_turn_elem_by_elem ) )
+        {
+            this->doSetPtrCParticleBuffer( particles_buffer );
+            this->doSetPtrCBeamElementsBuffer( beam_elements_buffer );
+        }
+
+        if( ( config_str != nullptr ) &&
+            ( std::strlen( config_str ) > size_t{ 0 } ) )
+        {
+            TrackJobBase::doSetConfigStr( config_str );
+            TrackJobBase::doParseConfigStr( this->ptrConfigStr() );
+        }
+    }
+
+    TrackJobCpu::TrackJobCpu(
         TrackJobCpu::buffer_t& SIXTRL_RESTRICT_REF particles_buffer,
         TrackJobCpu::buffer_t& SIXTRL_RESTRICT_REF beam_elements_buffer,
         TrackJobCpu::buffer_t* SIXTRL_RESTRICT ptr_output_buffer,
@@ -118,6 +164,8 @@ namespace SIXTRL_CXX_NAMESPACE
         c_buffer_t* ptr_belem_buffer = beam_elements_buffer.getCApiPtr();
         c_buffer_t* ptr_out_buffer   = ( ptr_output_buffer != nullptr )
             ? ptr_output_buffer->getCApiPtr() : nullptr;
+
+        this->doSetRequiresCollectFlag( false );
 
         if( TrackJobBase::doReset( ptr_part_buffer, ptr_belem_buffer,
                 ptr_out_buffer, until_turn_elem_by_elem ) )
@@ -136,9 +184,10 @@ namespace SIXTRL_CXX_NAMESPACE
             TrackJobBase::doSetConfigStr( config_str.c_str() );
             TrackJobBase::doParseConfigStr( this->ptrConfigStr() );
         }
+
     }
 
-    SIXTRL_HOST_FN TrackJobCpu::TrackJobCpu(
+    TrackJobCpu::TrackJobCpu(
         TrackJobCpu::buffer_t& SIXTRL_RESTRICT_REF particles_buffer,
         TrackJobCpu::size_type const num_particle_sets,
         TrackJobCpu::size_type const* SIXTRL_RESTRICT pset_indices_begin,
@@ -157,6 +206,7 @@ namespace SIXTRL_CXX_NAMESPACE
         c_buffer_t* ptr_out_buffer   = ( ptr_output_buffer != nullptr )
             ? ptr_output_buffer->getCApiPtr() : nullptr;
 
+        this->doSetRequiresCollectFlag( false );
         size_t const* pset_indices_end = pset_indices_begin;
 
         if( ( pset_indices_end != nullptr ) &&
@@ -187,21 +237,21 @@ namespace SIXTRL_CXX_NAMESPACE
         }
     }
 
-    SIXTRL_HOST_FN TrackJobCpu::~TrackJobCpu() SIXTRL_NOEXCEPT {}
+    TrackJobCpu::~TrackJobCpu() SIXTRL_NOEXCEPT {}
 
-    SIXTRL_HOST_FN TrackJobCpu::track_status_t TrackJobCpu::doTrackUntilTurn(
+    TrackJobCpu::track_status_t TrackJobCpu::doTrackUntilTurn(
         TrackJobCpu::size_type const until_turn )
     {
         return SIXTRL_CXX_NAMESPACE::track( *this, until_turn );
     }
 
-    SIXTRL_HOST_FN TrackJobCpu::track_status_t TrackJobCpu::doTrackElemByElem(
+    TrackJobCpu::track_status_t TrackJobCpu::doTrackElemByElem(
         TrackJobCpu::size_type const until_turn )
     {
         return SIXTRL_CXX_NAMESPACE::trackElemByElem( *this, until_turn );
     }
 
-    SIXTRL_HOST_FN TrackJobCpu::track_status_t TrackJobCpu::doTrackLine(
+    TrackJobCpu::track_status_t TrackJobCpu::doTrackLine(
         TrackJobCpu::size_type const beam_elements_begin_index,
         TrackJobCpu::size_type const beam_elements_end_index,
         bool const finish_turn )
@@ -210,13 +260,14 @@ namespace SIXTRL_CXX_NAMESPACE
             beam_elements_begin_index, beam_elements_end_index, finish_turn );
     }
 
-    SIXTRL_HOST_FN void TrackJobCpu::doCollect()
+    void TrackJobCpu::doCollect(
+        TrackJobCpu::collect_flag_t const flags )
     {
-        SIXTRL_CXX_NAMESPACE::collect( *this );
+        SIXTRL_CXX_NAMESPACE::collect( *this, flags );
         return;
     }
 
-    SIXTRL_HOST_FN TrackJobCpu::track_status_t track(
+    TrackJobCpu::track_status_t track(
         TrackJobCpu& SIXTRL_RESTRICT_REF job,
         TrackJobCpu::size_type const until_turn ) SIXTRL_NOEXCEPT
     {
@@ -268,7 +319,7 @@ namespace SIXTRL_CXX_NAMESPACE
         return status;
     }
 
-    SIXTRL_HOST_FN TrackJobCpu::track_status_t trackElemByElem(
+    TrackJobCpu::track_status_t trackElemByElem(
         TrackJobCpu& SIXTRL_RESTRICT_REF job,
         TrackJobCpu::size_type const until_turn ) SIXTRL_NOEXCEPT
     {
@@ -319,7 +370,7 @@ namespace SIXTRL_CXX_NAMESPACE
         return status;
     }
 
-    SIXTRL_HOST_FN TrackJobCpu::track_status_t trackLine(
+    TrackJobCpu::track_status_t trackLine(
         TrackJobCpu& SIXTRL_RESTRICT_REF job,
         TrackJobCpu::size_type const begin_index,
         TrackJobCpu::size_type const end_index,
@@ -359,18 +410,18 @@ namespace SIXTRL_CXX_NAMESPACE
     }
 }
 
-SIXTRL_HOST_FN ::NS(TrackJobCpu)* NS(TrackJobCpu_create)( void )
+::NS(TrackJobCpu)* NS(TrackJobCpu_create)( void )
 {
     return new SIXTRL_CXX_NAMESPACE::TrackJobCpu( nullptr );
 }
 
-SIXTRL_HOST_FN ::NS(TrackJobCpu)* NS(TrackJobCpu_create_from_config_str)(
+::NS(TrackJobCpu)* NS(TrackJobCpu_create_from_config_str)(
     const char *const SIXTRL_RESTRICT config_str )
 {
     return new SIXTRL_CXX_NAMESPACE::TrackJobCpu( config_str );
 }
 
-SIXTRL_HOST_FN ::NS(TrackJobCpu)* NS(TrackJobCpu_new)(
+::NS(TrackJobCpu)* NS(TrackJobCpu_new)(
     ::NS(Buffer)* SIXTRL_RESTRICT particles_buffer,
     ::NS(Buffer)* SIXTRL_RESTRICT beam_elements_buffer )
 {
@@ -385,7 +436,7 @@ SIXTRL_HOST_FN ::NS(TrackJobCpu)* NS(TrackJobCpu_new)(
         beam_elements_buffer, ptr_output_buffer, size_t{ 0 }, config_str );
 }
 
-SIXTRL_HOST_FN ::NS(TrackJobCpu)* NS(TrackJobCpu_new_with_output)(
+::NS(TrackJobCpu)* NS(TrackJobCpu_new_with_output)(
     ::NS(Buffer)* SIXTRL_RESTRICT particles_buffer,
     ::NS(Buffer)* SIXTRL_RESTRICT beam_elements_buffer,
     ::NS(Buffer)* SIXTRL_RESTRICT output_buffer,
@@ -395,7 +446,7 @@ SIXTRL_HOST_FN ::NS(TrackJobCpu)* NS(TrackJobCpu_new_with_output)(
         beam_elements_buffer, output_buffer, until_turn_elem_by_elem );
 }
 
-SIXTRL_HOST_FN ::NS(TrackJobCpu)* NS(TrackJobCpu_new_detailed)(
+::NS(TrackJobCpu)* NS(TrackJobCpu_new_detailed)(
     ::NS(Buffer)* SIXTRL_RESTRICT particles_buffer,
     ::NS(buffer_size_t) const num_particle_sets,
     ::NS(buffer_size_t) const* SIXTRL_RESTRICT particle_set_indices_begin,
@@ -409,21 +460,18 @@ SIXTRL_HOST_FN ::NS(TrackJobCpu)* NS(TrackJobCpu_new_detailed)(
         output_buffer, until_turn_elem_by_elem, config_str );
 }
 
-SIXTRL_HOST_FN void NS(TrackJobCpu_delete)(
-    ::NS(TrackJobCpu)* SIXTRL_RESTRICT job )
+void NS(TrackJobCpu_delete)( ::NS(TrackJobCpu)* SIXTRL_RESTRICT job )
 {
     delete job;
     return;
 }
 
-SIXTRL_HOST_FN void NS(TrackJobCpu_clear)(
-    ::NS(TrackJobCpu)* SIXTRL_RESTRICT job )
+void NS(TrackJobCpu_clear)( ::NS(TrackJobCpu)* SIXTRL_RESTRICT job )
 {
     if( job != nullptr ) job->clear();
 }
 
-SIXTRL_HOST_FN bool NS(TrackJobCpu_reset)(
-    ::NS(TrackJobCpu)* SIXTRL_RESTRICT job,
+bool NS(TrackJobCpu_reset)( ::NS(TrackJobCpu)* SIXTRL_RESTRICT job,
     ::NS(Buffer)* SIXTRL_RESTRICT particles_buffer,
     ::NS(Buffer)* SIXTRL_RESTRICT beam_elements_buffer,
     ::NS(Buffer)* SIXTRL_RESTRICT output_buffer )
@@ -433,8 +481,7 @@ SIXTRL_HOST_FN bool NS(TrackJobCpu_reset)(
         : false;
 }
 
-SIXTRL_HOST_FN bool NS(TrackJobCpu_reset_with_output)(
-    ::NS(TrackJobCpu)* SIXTRL_RESTRICT job,
+bool NS(TrackJobCpu_reset_with_output)( ::NS(TrackJobCpu)* SIXTRL_RESTRICT job,
     ::NS(Buffer)* SIXTRL_RESTRICT particles_buffer,
     ::NS(Buffer)* SIXTRL_RESTRICT beam_elements_buffer,
     ::NS(Buffer)* SIXTRL_RESTRICT output_buffer,
@@ -446,8 +493,7 @@ SIXTRL_HOST_FN bool NS(TrackJobCpu_reset_with_output)(
         : false;
 }
 
-SIXTRL_HOST_FN bool NS(TrackJobCpu_reset_detailed)(
-    ::NS(TrackJobCpu)* SIXTRL_RESTRICT job,
+bool NS(TrackJobCpu_reset_detailed)( ::NS(TrackJobCpu)* SIXTRL_RESTRICT job,
     ::NS(Buffer)* SIXTRL_RESTRICT particles_buffer,
     ::NS(buffer_size_t) const num_particle_sets,
     ::NS(buffer_size_t) const* SIXTRL_RESTRICT pset_indices_begin,
@@ -461,30 +507,34 @@ SIXTRL_HOST_FN bool NS(TrackJobCpu_reset_detailed)(
         : false;
 }
 
-SIXTRL_HOST_FN bool NS(TrackJobCpu_assign_output_buffer)(
+bool NS(TrackJobCpu_assign_output_buffer)(
     ::NS(TrackJobCpu)* SIXTRL_RESTRICT job,
     ::NS(Buffer)* SIXTRL_RESTRICT out_buffer )
 {
     return ( job != nullptr ) ? job->assignOutputBuffer( out_buffer ) : false;
 }
 
-SIXTRL_HOST_FN void NS(TrackJobCpu_collect)(
-    ::NS(TrackJobCpu)* SIXTRL_RESTRICT job )
+void NS(TrackJobCpu_collect)( ::NS(TrackJobCpu)* SIXTRL_RESTRICT job )
 {
     SIXTRL_ASSERT( job != nullptr );
     SIXTRL_CXX_NAMESPACE::collect( *job );
-
-    return;
 }
 
-SIXTRL_HOST_FN ::NS(track_status_t) NS(TrackJobCpu_track_until_turn)(
+void NS(TrackJobCpu_collect_detailed)( NS(TrackJobCpu)* SIXTRL_RESTRICT job,
+    NS(track_job_collect_flag_t) const flags )
+{
+    SIXTRL_ASSERT( job != nullptr );
+    SIXTRL_CXX_NAMESPACE::collect( *job, flags );
+}
+
+::NS(track_status_t) NS(TrackJobCpu_track_until_turn)(
     ::NS(TrackJobCpu)* SIXTRL_RESTRICT job, ::NS(buffer_size_t) const turn )
 {
     SIXTRL_ASSERT( job != nullptr );
     return SIXTRL_CXX_NAMESPACE::track( *job, turn );
 }
 
-SIXTRL_HOST_FN ::NS(track_status_t) NS(TrackJobCpu_track_elem_by_elem)(
+::NS(track_status_t) NS(TrackJobCpu_track_elem_by_elem)(
     ::NS(TrackJobCpu)* SIXTRL_RESTRICT job, ::NS(buffer_size_t) const turn )
 {
     SIXTRL_ASSERT( job != nullptr );

--- a/sixtracklib/common/particles.h
+++ b/sixtracklib/common/particles.h
@@ -22,8 +22,10 @@
 #if !defined( SIXTRL_NO_INCLUDES )
     #include "sixtracklib/common/definitions.h"
     #include "sixtracklib/common/internal/buffer_main_defines.h"
+    #include "sixtracklib/common/internal/buffer_object_defines.h"
     #include "sixtracklib/common/internal/particles_defines.h"
     #include "sixtracklib/common/buffer/buffer_type.h"
+    #include "sixtracklib/common/buffer/buffer_object.h"
 #endif /* !defined( SIXTRL_NO_INCLUDES ) */
 
 #if !defined( _GPUCODE ) && defined( __cplusplus )

--- a/sixtracklib/common/track/definitions.h
+++ b/sixtracklib/common/track/definitions.h
@@ -1,0 +1,104 @@
+#ifndef SIXTRACKLIB_COMMON_TRACK_DEFINITIONS_H__
+#define SIXTRACKLIB_COMMON_TRACK_DEFINITIONS_H__
+
+#if !defined( SIXTRL_NO_INCLUDES )
+    #include "sixtracklib/common/definitions.h"
+    #include "sixtracklib/common/buffer/buffer_type.h"
+#endif /* !defined( SIXTRL_NO_INCLUDES ) */
+
+/* ------------------------------------------------------------------------- */
+
+#if !defined( SIXTRL_TRACK_SUCCESS )
+    #define SIXTRL_TRACK_SUCCESS 0
+#endif /* !defined( SIXTRL_TRACK_SUCCESS ) */
+
+#if defined( __cplusplus ) && !defined( _GPUCODE )
+extern "C" {
+#endif /* defined( __cplusplus ) && ( !defined( _GPUCODE ) */
+
+typedef SIXTRL_INT32_T      NS(track_status_t);
+
+#if !defined( _GPUCODE )
+typedef SIXTRL_UINT16_T     NS(track_job_collect_flag_t);
+typedef NS(buffer_size_t)   NS(track_job_size_t);
+typedef SIXTRL_INT64_T      NS(track_job_type_t);
+
+/* ------------------------------------------------------------------------- */
+
+SIXTRL_STATIC_VAR NS(track_status_t) const
+    NS(TRACK_SUCCESS) = ( NS(track_status_t) )0u;
+
+SIXTRL_STATIC_VAR NS(track_job_collect_flag_t) const
+    NS(TRACK_JOB_COLLECT_NONE) = ( NS(track_job_collect_flag_t) )0x00;
+
+SIXTRL_STATIC_VAR NS(track_job_collect_flag_t) const
+    NS(TRACK_JOB_COLLECT_PARTICLES) = ( NS(track_job_collect_flag_t) )0x01;
+
+SIXTRL_STATIC_VAR NS(track_job_collect_flag_t) const
+    NS(TRACK_JOB_COLLECT_BEAM_ELEMENTS) = ( NS(track_job_collect_flag_t) )0x02;
+
+SIXTRL_STATIC_VAR NS(track_job_collect_flag_t) const
+    NS(TRACK_JOB_COLLECT_OUTPUT) = ( NS(track_job_collect_flag_t) )0x04;
+
+SIXTRL_STATIC_VAR NS(track_job_collect_flag_t) const
+    NS(TRACK_JOB_COLLECT_ALL) = ( NS(track_job_collect_flag_t) )0x07;
+
+SIXTRL_STATIC_VAR NS(track_job_collect_flag_t) const
+    NS(TRACK_JOB_COLLECT_DEFAULT_FLAGS) = ( NS(track_job_collect_flag_t) )0x05;
+
+SIXTRL_STATIC_VAR NS(track_job_size_t) const
+    NS(TRACK_JOB_DEFAULT_NUM_PARTICLE_SETS) = ( NS(track_job_size_t) )1u;
+
+SIXTRL_STATIC_VAR NS(track_job_size_t) const
+    NS(TRACK_JOB_DEFAULT_PARTICLE_SET_INDICES)[] = { 0u };
+
+#endif /* !defined( _GPUCODE ) */
+
+#if defined( __cplusplus ) && !defined( _GPUCODE )
+}
+#endif /* defined( __cplusplus ) && ( !defined( _GPUCODE ) */
+
+#if defined( __cplusplus )
+namespace SIXTRL_CXX_NAMESPACE
+{
+    using track_status_t = ::NS(track_status_t);
+    SIXTRL_STATIC_VAR track_status_t const TRACK_SUCCESS = track_status_t{ 0 };
+}
+#endif /* defined( __cplusplus )  */
+
+
+#if defined( __cplusplus ) && !defined( _GPUCODE )
+namespace SIXTRL_CXX_NAMESPACE
+{
+    using track_job_collect_flag_t = ::NS(track_job_collect_flag_t);
+    using track_job_size_t         = ::NS(track_job_size_t);
+    using track_job_type_t         = ::NS(track_job_type_t);
+
+    SIXTRL_STATIC_VAR track_job_collect_flag_t const
+        TRACK_JOB_COLLECT_NONE = track_job_collect_flag_t{ 0x0000 };
+
+    SIXTRL_STATIC_VAR track_job_collect_flag_t const
+        TRACK_JOB_COLLECT_PARTICLES = track_job_collect_flag_t{ 0x0001 };
+
+    SIXTRL_STATIC_VAR track_job_collect_flag_t const
+        TRACK_JOB_COLLECT_BEAM_ELEMENTS = track_job_collect_flag_t{ 0x0002 };
+
+    SIXTRL_STATIC_VAR track_job_collect_flag_t const
+        TRACK_JOB_COLLECT_OUTPUT = track_job_collect_flag_t{ 0x0004 };
+
+    SIXTRL_STATIC_VAR track_job_collect_flag_t const
+        TRACK_JOB_COLLECT_ALL = track_job_collect_flag_t{ 0x0007 };
+
+    SIXTRL_STATIC_VAR track_job_collect_flag_t const
+        TRACK_JOB_COLLECT_DEFAULT_FLAGS = track_job_collect_flag_t{ 0x0005 };
+
+    SIXTRL_STATIC_VAR track_job_size_t const
+        TRACK_JOB_DEFAULT_NUM_PARTICLE_SETS = track_job_size_t{ 1 };
+
+    SIXTRL_STATIC_VAR track_job_size_t const
+        TRACK_JOB_DEFAULT_PARTICLE_SET_INDICES[] = { track_job_size_t{ 0 } };
+}
+#endif /* defined( __cplusplus ) && !defined( _GPUCODE ) */
+
+#endif /* SIXTRACKLIB_COMMON_TRACK_DEFINITIONS_H__ */
+/* end: sixtracklib/common/track/definitions.h */

--- a/sixtracklib/common/track_job.h
+++ b/sixtracklib/common/track_job.h
@@ -182,20 +182,77 @@ NS(TrackJob_track_line)( NS(TrackJobBase)* SIXTRL_RESTRICT job,
     NS(buffer_size_t) const beam_elem_end_index,
     bool const finish_turn );
 
+/* ------------------------------------------------------------------------- */
+
 SIXTRL_EXTERN SIXTRL_HOST_FN void NS(TrackJob_collect)(
     NS(TrackJobBase)* SIXTRL_RESTRICT job );
+
+SIXTRL_EXTERN SIXTRL_HOST_FN void NS(TrackJob_collect_detailed)(
+    NS(TrackJobBase)* SIXTRL_RESTRICT job,
+    NS(track_job_collect_flag_t) const flags );
+
+SIXTRL_EXTERN SIXTRL_HOST_FN void NS(TrackJob_collect_particles)(
+    NS(TrackJobBase)* SIXTRL_RESTRICT job );
+
+SIXTRL_EXTERN SIXTRL_HOST_FN void NS(TrackJob_collect_beam_elements)(
+    NS(TrackJobBase)* SIXTRL_RESTRICT job );
+
+SIXTRL_EXTERN SIXTRL_HOST_FN void NS(TrackJob_collect_output)(
+    NS(TrackJobBase)* SIXTRL_RESTRICT job );
+
+SIXTRL_EXTERN SIXTRL_HOST_FN void NS(TrackJob_enable_collect_particles)(
+    NS(TrackJobBase)* SIXTRL_RESTRICT job );
+
+SIXTRL_EXTERN SIXTRL_HOST_FN void NS(TrackJob_disable_collect_particles)(
+    NS(TrackJobBase)* SIXTRL_RESTRICT job );
+
+SIXTRL_EXTERN SIXTRL_HOST_FN bool NS(TrackJob_is_collecting_particles)(
+    const NS(TrackJobBase) *const SIXTRL_RESTRICT job );
+
+SIXTRL_EXTERN SIXTRL_HOST_FN void NS(TrackJob_enable_collect_beam_elements)(
+    NS(TrackJobBase)* SIXTRL_RESTRICT job );
+
+SIXTRL_EXTERN SIXTRL_HOST_FN void NS(TrackJob_disable_collect_beam_elements)(
+    NS(TrackJobBase)* SIXTRL_RESTRICT job );
+
+SIXTRL_EXTERN SIXTRL_HOST_FN bool NS(TrackJob_is_collecting_beam_elements)(
+    const NS(TrackJobBase) *const SIXTRL_RESTRICT job );
+
+SIXTRL_EXTERN SIXTRL_HOST_FN void NS(TrackJob_enable_collect_output)(
+    NS(TrackJobBase)* SIXTRL_RESTRICT job );
+
+SIXTRL_EXTERN SIXTRL_HOST_FN void NS(TrackJob_disable_collect_output)(
+    NS(TrackJobBase)* SIXTRL_RESTRICT job );
+
+SIXTRL_EXTERN SIXTRL_HOST_FN bool NS(TrackJob_is_collecting_output)(
+    const NS(TrackJobBase) *const SIXTRL_RESTRICT job );
+
+SIXTRL_EXTERN SIXTRL_HOST_FN NS(track_job_collect_flag_t)
+NS(TrackJob_get_collect_flags)(
+    const NS(TrackJobBase) *const SIXTRL_RESTRICT job );
+
+SIXTRL_EXTERN SIXTRL_HOST_FN void NS(TrackJob_set_collect_flags)(
+    NS(TrackJobBase)* SIXTRL_RESTRICT job,
+    NS(track_job_collect_flag_t) const flag );
+
+SIXTRL_EXTERN SIXTRL_HOST_FN bool requiresCollect(
+    const NS(TrackJobBase) *const SIXTRL_RESTRICT job );
 
 /* ------------------------------------------------------------------------- */
 
 SIXTRL_EXTERN SIXTRL_HOST_FN void NS(TrackJob_clear)(
     NS(TrackJobBase)* SIXTRL_RESTRICT job );
 
-SIXTRL_EXTERN SIXTRL_HOST_FN void NS(TrackJob_collect)(
-    NS(TrackJobBase)* SIXTRL_RESTRICT job );
-
 SIXTRL_EXTERN SIXTRL_HOST_FN bool NS(TrackJob_reset)(
     NS(TrackJobBase)* SIXTRL_RESTRICT job,
     NS(Buffer)* SIXTRL_RESTRICT particles_buffer,
+    NS(Buffer)* SIXTRL_RESTRICT beam_elem_buffer,
+    NS(Buffer)* SIXTRL_RESTRICT output_buffer );
+
+SIXTRL_EXTERN SIXTRL_HOST_FN bool NS(TrackJob_reset_particle_set)(
+    NS(TrackJobBase)* SIXTRL_RESTRICT job,
+    NS(Buffer)* SIXTRL_RESTRICT particles_buffer,
+    NS(buffer_size_t) const particle_set_index,
     NS(Buffer)* SIXTRL_RESTRICT beam_elem_buffer,
     NS(Buffer)* SIXTRL_RESTRICT output_buffer );
 
@@ -214,6 +271,10 @@ SIXTRL_EXTERN SIXTRL_HOST_FN bool NS(TrackJob_reset_detailed)(
     NS(Buffer)* SIXTRL_RESTRICT beam_elem_buffer,
     NS(Buffer)* SIXTRL_RESTRICT output_buffer,
     NS(buffer_size_t) const dump_elem_by_elem_turns );
+
+SIXTRL_EXTERN SIXTRL_HOST_FN bool NS(TrackJob_select_particle_set)(
+    NS(TrackJobBase)* SIXTRL_RESTRICT job,
+    NS(buffer_size_t) const particle_set_index );
 
 SIXTRL_EXTERN SIXTRL_HOST_FN bool NS(TrackJob_assign_output_buffer)(
     NS(TrackJobBase)* SIXTRL_RESTRICT job,

--- a/sixtracklib/common/track_job_cpu.h
+++ b/sixtracklib/common/track_job_cpu.h
@@ -47,6 +47,8 @@ namespace SIXTRL_CXX_NAMESPACE
         using elem_by_elem_config_t = _base_t::elem_by_elem_config_t;
         using track_status_t        = _base_t::track_status_t;
         using type_t                = _base_t::type_t;
+        using output_buffer_flag_t  = _base_t::output_buffer_flag_t;
+        using collect_flag_t        = _base_t::collect_flag_t;
 
         SIXTRL_HOST_FN explicit TrackJobCpu(
             std::string const& config_str = std::string{} );
@@ -56,6 +58,14 @@ namespace SIXTRL_CXX_NAMESPACE
 
         SIXTRL_HOST_FN TrackJobCpu(
             c_buffer_t* SIXTRL_RESTRICT particles_buffer,
+            c_buffer_t* SIXTRL_RESTRICT beam_elements_buffer,
+            c_buffer_t* SIXTRL_RESTRICT ptr_output_buffer = nullptr,
+            size_type const until_turn_elem_by_elem       = size_type{ 0 },
+            const char *const SIXTRL_RESTRICT config_str  = nullptr );
+
+        SIXTRL_HOST_FN TrackJobCpu(
+            c_buffer_t* SIXTRL_RESTRICT particles_buffer,
+            size_type const particle_set_index,
             c_buffer_t* SIXTRL_RESTRICT beam_elements_buffer,
             c_buffer_t* SIXTRL_RESTRICT ptr_output_buffer = nullptr,
             size_type const until_turn_elem_by_elem       = size_type{ 0 },
@@ -82,6 +92,14 @@ namespace SIXTRL_CXX_NAMESPACE
 
         SIXTRL_HOST_FN TrackJobCpu(
             buffer_t& SIXTRL_RESTRICT_REF particles_buffer,
+            buffer_t& SIXTRL_RESTRICT_REF beam_elements_buffer,
+            buffer_t* SIXTRL_RESTRICT ptr_output_buffer = nullptr,
+            size_type const until_turn_elem_by_elem = size_type{ 0 },
+            std::string const& config_str = std::string{} );
+
+        SIXTRL_HOST_FN TrackJobCpu(
+            buffer_t& SIXTRL_RESTRICT_REF particles_buffer,
+            size_type const particle_set_index,
             buffer_t& SIXTRL_RESTRICT_REF beam_elements_buffer,
             buffer_t* SIXTRL_RESTRICT ptr_output_buffer = nullptr,
             size_type const until_turn_elem_by_elem = size_type{ 0 },
@@ -130,10 +148,13 @@ namespace SIXTRL_CXX_NAMESPACE
             size_type const beam_elements_end_index,
             bool const finish_turn ) override;
 
-        virtual void doCollect() override;
+        virtual void doCollect( collect_flag_t const flags ) override;
     };
 
     SIXTRL_HOST_FN void collect( TrackJobCpu& job ) SIXTRL_NOEXCEPT;
+
+    SIXTRL_HOST_FN void collect( TrackJobCpu& job,
+        track_job_collect_flag_t const flags ) SIXTRL_NOEXCEPT;
 
     SIXTRL_HOST_FN TrackJobCpu::track_status_t track(
         TrackJobCpu& SIXTRL_RESTRICT_REF job,
@@ -234,6 +255,10 @@ SIXTRL_EXTERN SIXTRL_HOST_FN bool NS(TrackJobCpu_assign_output_buffer)(
 SIXTRL_EXTERN SIXTRL_HOST_FN void NS(TrackJobCpu_collect)(
     NS(TrackJobCpu)* SIXTRL_RESTRICT job );
 
+SIXTRL_EXTERN SIXTRL_HOST_FN void NS(TrackJobCpu_collect_detailed)(
+    NS(TrackJobCpu)* SIXTRL_RESTRICT job,
+    NS(track_job_collect_flag_t) const flags );
+
 SIXTRL_EXTERN SIXTRL_HOST_FN NS(track_status_t)
 NS(TrackJobCpu_track_until_turn)( NS(TrackJobCpu)* SIXTRL_RESTRICT job,
     NS(buffer_size_t) const until_turn );
@@ -260,7 +285,7 @@ NS(TrackJobCpu_track_line)( NS(TrackJobCpu)* SIXTRL_RESTRICT job,
 namespace SIXTRL_CXX_NAMESPACE
 {
     template< typename PartSetIndexIter >
-    SIXTRL_HOST_FN TrackJobCpu::TrackJobCpu(
+    TrackJobCpu::TrackJobCpu(
         TrackJobCpu::c_buffer_t* SIXTRL_RESTRICT particles_buffer,
         PartSetIndexIter particle_set_indices_begin,
         PartSetIndexIter particle_set_indices_end,
@@ -300,7 +325,7 @@ namespace SIXTRL_CXX_NAMESPACE
     }
 
     template< typename PartSetIndexIter >
-    SIXTRL_HOST_FN TrackJobCpu::TrackJobCpu(
+    TrackJobCpu::TrackJobCpu(
         TrackJobCpu::buffer_t& SIXTRL_RESTRICT_REF particles_buffer,
         PartSetIndexIter particle_set_indices_begin,
         PartSetIndexIter particle_set_indices_end,
@@ -350,7 +375,13 @@ namespace SIXTRL_CXX_NAMESPACE
         }
     }
 
-    SIXTRL_INLINE SIXTRL_HOST_FN void collect( TrackJobCpu& ) SIXTRL_NOEXCEPT
+    SIXTRL_INLINE void collect( TrackJobCpu& ) SIXTRL_NOEXCEPT
+    {
+        return;
+    }
+
+    SIXTRL_INLINE void collect( TrackJobCpu&,
+        track_job_collect_flag_t const ) SIXTRL_NOEXCEPT
     {
         return;
     }

--- a/sixtracklib/opencl/context.h
+++ b/sixtracklib/opencl/context.h
@@ -65,7 +65,9 @@ namespace SIXTRL_CXX_NAMESPACE
 
         /* - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - */
 
-        bool assignParticleArg( ClArgument& SIXTRL_RESTRICT_REF arg );
+        bool assignParticleArg( ClArgument& SIXTRL_RESTRICT_REF arg,
+            size_type const particle_set_index = size_type{ 0 } );
+
         bool assignBeamElementsArg( ClArgument& SIXTRL_RESTRICT_REF arg );
         bool assignOutputBufferArg( ClArgument& SIXTRL_RESTRICT_REF arg );
 
@@ -93,6 +95,31 @@ namespace SIXTRL_CXX_NAMESPACE
 
         int track( ClArgument& particles_arg, ClArgument& beam_elements_arg,
                    num_turns_t const turn, kernel_id_t const track_kernel_id );
+
+        /* - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - */
+
+        bool hasLineTrackingKernel() const SIXTRL_NOEXCEPT;
+        kernel_id_t lineTrackingKernelId() const SIXTRL_NOEXCEPT;
+        bool setTrackLineKernelId( kernel_id_t const kernel_id );
+
+        int trackLine( size_type const line_begin_idx,
+                       size_type const line_end_idx, bool const finish_turn );
+
+        int trackLine( size_type const line_begin_idx, size_type line_end_idx,
+                       bool const finish_turn, kernel_id_t const kernel_id );
+
+        int trackLine( ClArgument& SIXTRL_RESTRICT_REF particles_arg,
+                       size_type const particle_set_index,
+                       ClArgument& SIXTRL_RESTRICT_REF beam_elements_arg,
+                       size_type const line_begin_idx,
+                       size_type const line_end_idx, bool const finish_turn );
+
+        int trackLine( ClArgument& SIXTRL_RESTRICT_REF particles_arg,
+                       size_type const particle_set_index,
+                       ClArgument& SIXTRL_RESTRICT_REF beam_elements_arg,
+                       size_type const line_begin_idx,
+                       size_type const line_end_idx, bool const finish_turn,
+                       kernel_id_t const track_kernel_id );
 
         /* - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - */
 
@@ -205,12 +232,14 @@ namespace SIXTRL_CXX_NAMESPACE
         program_id_t m_track_until_turn_program_id;
         program_id_t m_track_single_turn_program_id;
         program_id_t m_track_elem_by_elem_program_id;
+        program_id_t m_track_line_program_id;
         program_id_t m_assign_be_mon_out_buffer_program_id;
         program_id_t m_clear_be_mon_program_id;
 
         kernel_id_t  m_track_until_turn_kernel_id;
         kernel_id_t  m_track_single_turn_kernel_id;
         kernel_id_t  m_track_elem_by_elem_kernel_id;
+        kernel_id_t  m_track_line_kernel_id;
         kernel_id_t  m_assign_be_mon_out_buffer_kernel_id;
         kernel_id_t  m_clear_be_mon_kernel_id;
 
@@ -241,38 +270,45 @@ typedef SIXTRL_INT64_T NS(context_num_turns_t);
 extern "C" {
 #endif /* !defined( _GPUCODE ) && defined( __cplusplus ) */
 
-SIXTRL_HOST_FN NS(ClContext)* NS(ClContext_create)();
-SIXTRL_HOST_FN NS(ClContext)* NS(ClContext_new)( const char* node_id_str );
-SIXTRL_HOST_FN void NS(ClContext_delete)( NS(ClContext)* SIXTRL_RESTRICT ctx );
-SIXTRL_HOST_FN void NS(ClContext_clear)(  NS(ClContext)* SIXTRL_RESTRICT ctx );
+SIXTRL_EXTERN SIXTRL_HOST_FN NS(ClContext)* NS(ClContext_create)();
+
+SIXTRL_EXTERN SIXTRL_HOST_FN NS(ClContext)* NS(ClContext_new)(
+    const char* node_id_str );
+
+SIXTRL_EXTERN SIXTRL_HOST_FN void NS(ClContext_delete)(
+    NS(ClContext)* SIXTRL_RESTRICT ctx );
+
+SIXTRL_EXTERN SIXTRL_HOST_FN void NS(ClContext_clear)(
+    NS(ClContext)* SIXTRL_RESTRICT ctx );
 
 /* ========================================================================= */
 
-SIXTRL_HOST_FN bool NS(ClContext_has_tracking_kernel)(
+SIXTRL_EXTERN SIXTRL_HOST_FN bool NS(ClContext_has_tracking_kernel)(
     const NS(ClContext) *const SIXTRL_RESTRICT ctx );
 
-SIXTRL_HOST_FN int NS(ClContext_get_tracking_kernel_id)(
+SIXTRL_EXTERN SIXTRL_HOST_FN int NS(ClContext_get_tracking_kernel_id)(
     const NS(ClContext) *const SIXTRL_RESTRICT ctx );
 
-SIXTRL_HOST_FN bool NS(ClContext_set_tracking_kernel_id)(
+SIXTRL_EXTERN SIXTRL_HOST_FN bool NS(ClContext_set_tracking_kernel_id)(
     NS(ClContext)* SIXTRL_RESTRICT ctx, int const kernel_id );
 
 /* - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - */
 
-SIXTRL_HOST_FN int NS(ClContext_continue_tracking)(
+SIXTRL_EXTERN SIXTRL_HOST_FN int NS(ClContext_continue_tracking)(
     NS(ClContext)* SIXTRL_RESTRICT ctx, NS(context_num_turns_t) const turn );
 
-SIXTRL_HOST_FN int NS(ClContext_continue_tracking_with_kernel_id)(
+SIXTRL_EXTERN SIXTRL_HOST_FN int
+NS(ClContext_continue_tracking_with_kernel_id)(
     NS(ClContext)* SIXTRL_RESTRICT ctx, int const track_kernel_id,
     NS(context_num_turns_t) const turn );
 
-SIXTRL_HOST_FN int NS(ClContext_track)(
+SIXTRL_EXTERN SIXTRL_HOST_FN int NS(ClContext_track)(
     NS(ClContext)* SIXTRL_RESTRICT ctx,
     NS(ClArgument)* SIXTRL_RESTRICT ptr_particles_arg,
     NS(ClArgument)* SIXTRL_RESTRICT ptr_beam_elements_arg,
     NS(context_num_turns_t) const turn );
 
-SIXTRL_HOST_FN int NS(ClContext_track_with_kernel_id)(
+SIXTRL_EXTERN SIXTRL_HOST_FN int NS(ClContext_track_with_kernel_id)(
     NS(ClContext)* SIXTRL_RESTRICT ctx,
     NS(ClArgument)* SIXTRL_RESTRICT ptr_particles_arg,
     NS(ClArgument)* SIXTRL_RESTRICT ptr_beam_elements_arg,
@@ -280,29 +316,77 @@ SIXTRL_HOST_FN int NS(ClContext_track_with_kernel_id)(
 
 /* ------------------------------------------------------------------------- */
 
-SIXTRL_HOST_FN bool NS(ClContext_has_single_turn_tracking_kernel)(
+
+SIXTRL_EXTERN SIXTRL_HOST_FN bool NS(ClContext_has_line_tracking_kernel)(
     const NS(ClContext) *const SIXTRL_RESTRICT ctx );
 
-SIXTRL_HOST_FN int NS(ClContext_get_single_turn_tracking_kernel_id)(
+SIXTRL_EXTERN SIXTRL_HOST_FN int NS(ClContext_get_line_tracking_kernel_id)(
     const NS(ClContext) *const SIXTRL_RESTRICT ctx );
 
-SIXTRL_HOST_FN bool NS(ClContext_set_single_turn_tracking_kernel_id)(
+SIXTRL_EXTERN SIXTRL_HOST_FN bool NS(ClContext_set_line_tracking_kernel_id)(
+    NS(ClContext)* SIXTRL_RESTRICT ctx, int const kernel_id );
+
+/* - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - */
+
+SIXTRL_EXTERN SIXTRL_HOST_FN int
+NS(ClContext_continue_line_tracking)( NS(ClContext)* SIXTRL_RESTRICT ctx,
+    NS(buffer_size_t) const line_begin_idx,
+    NS(buffer_size_t) const line_end_idx, bool const finish_turn );
+
+SIXTRL_EXTERN SIXTRL_HOST_FN int
+NS(ClContext_continue_line_tracking_with_kernel_id)(
+    NS(ClContext)* SIXTRL_RESTRICT ctx,
+    NS(buffer_size_t) const line_begin_idx,
+    NS(buffer_size_t) const line_end_idx,
+    bool const finish_turn, int const line_tracking_kernel_id );
+
+SIXTRL_EXTERN SIXTRL_HOST_FN int NS(ClContext_track_line)(
+    NS(ClContext)* SIXTRL_RESTRICT ctx,
+    NS(ClArgument)* SIXTRL_RESTRICT ptr_particles_arg,
+    NS(buffer_size_t) const particle_set_index,
+    NS(ClArgument)* SIXTRL_RESTRICT ptr_beam_elements_arg,
+    NS(buffer_size_t) const line_begin_idx,
+    NS(buffer_size_t) const line_end_idx, bool const finish_turn );
+
+SIXTRL_EXTERN SIXTRL_HOST_FN int NS(ClContext_track_line_with_kernel_id)(
+    NS(ClContext)* SIXTRL_RESTRICT ctx,
+    NS(ClArgument)* SIXTRL_RESTRICT ptr_particles_arg,
+    NS(buffer_size_t) const particle_set_index,
+    NS(ClArgument)* SIXTRL_RESTRICT ptr_beam_elements_arg,
+    NS(buffer_size_t) const line_begin_idx,
+    NS(buffer_size_t) const line_end_idx, bool const finish_turn,
+    int const line_tracking_kernel_id );
+
+/* ------------------------------------------------------------------------- */
+
+SIXTRL_EXTERN SIXTRL_HOST_FN bool
+NS(ClContext_has_single_turn_tracking_kernel)(
+    const NS(ClContext) *const SIXTRL_RESTRICT ctx );
+
+SIXTRL_EXTERN SIXTRL_HOST_FN int
+NS(ClContext_get_single_turn_tracking_kernel_id)(
+    const NS(ClContext) *const SIXTRL_RESTRICT ctx );
+
+SIXTRL_EXTERN SIXTRL_HOST_FN bool
+NS(ClContext_set_single_turn_tracking_kernel_id)(
     NS(ClContext)* SIXTRL_RESTRICT ctx, int const tracking_kernel_id );
 
 /* - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - */
 
-SIXTRL_HOST_FN int NS(ClContext_continue_tracking_single_turn)(
+SIXTRL_EXTERN SIXTRL_HOST_FN int NS(ClContext_continue_tracking_single_turn)(
     NS(ClContext)* SIXTRL_RESTRICT ctx );
 
-SIXTRL_HOST_FN int NS(ClContext_continue_tracking_single_turn_with_kernel_id)(
+SIXTRL_EXTERN SIXTRL_HOST_FN int
+NS(ClContext_continue_tracking_single_turn_with_kernel_id)(
     NS(ClContext)* SIXTRL_RESTRICT ctx, int const kernel_id );
 
-SIXTRL_HOST_FN int NS(ClContext_track_single_turn)(
+SIXTRL_EXTERN SIXTRL_HOST_FN int NS(ClContext_track_single_turn)(
     NS(ClContext)* SIXTRL_RESTRICT ctx,
     NS(ClArgument)* SIXTRL_RESTRICT ptr_particles_arg,
     NS(ClArgument)* SIXTRL_RESTRICT ptr_beam_elements_arg );
 
-SIXTRL_HOST_FN int NS(ClContext_track_single_turn_with_kernel_id)(
+SIXTRL_EXTERN SIXTRL_HOST_FN int
+NS(ClContext_track_single_turn_with_kernel_id)(
     NS(ClContext)* SIXTRL_RESTRICT ctx,
     NS(ClArgument)* SIXTRL_RESTRICT ptr_particles_arg,
     NS(ClArgument)* SIXTRL_RESTRICT ptr_beam_elements_arg,
@@ -310,29 +394,32 @@ SIXTRL_HOST_FN int NS(ClContext_track_single_turn_with_kernel_id)(
 
 /* ------------------------------------------------------------------------- */
 
-SIXTRL_HOST_FN bool NS(ClContext_has_element_by_element_tracking_kernel)(
+SIXTRL_EXTERN SIXTRL_HOST_FN bool
+NS(ClContext_has_element_by_element_tracking_kernel)(
     const NS(ClContext) *const SIXTRL_RESTRICT ctx );
 
-SIXTRL_HOST_FN int NS(ClContext_get_element_by_element_tracking_kernel_id)(
+SIXTRL_EXTERN SIXTRL_HOST_FN int
+NS(ClContext_get_element_by_element_tracking_kernel_id)(
     const NS(ClContext) *const SIXTRL_RESTRICT ctx );
 
-SIXTRL_HOST_FN bool NS(ClContext_set_element_by_element_tracking_kernel_id)(
+SIXTRL_EXTERN SIXTRL_HOST_FN bool
+NS(ClContext_set_element_by_element_tracking_kernel_id)(
     NS(ClContext)* SIXTRL_RESTRICT ctx, int const tracking_kernel_id );
 
 /* - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - */
 
-SIXTRL_HOST_FN int NS(ClContext_continue_tracking_element_by_element)(
-    NS(ClContext)* SIXTRL_RESTRICT ctx,
-    NS(buffer_size_t) const until_turn,
+SIXTRL_EXTERN SIXTRL_HOST_FN int
+NS(ClContext_continue_tracking_element_by_element)(
+    NS(ClContext)* SIXTRL_RESTRICT ctx, NS(buffer_size_t) const until_turn,
     NS(buffer_size_t) const out_particle_block_offset );
 
-SIXTRL_HOST_FN int NS(ClContext_continue_tracking_element_by_element_with_kernel_id)(
-    NS(ClContext)* SIXTRL_RESTRICT ctx,
-    NS(buffer_size_t) const until_turn,
+SIXTRL_EXTERN SIXTRL_HOST_FN int
+NS(ClContext_continue_tracking_element_by_element_with_kernel_id)(
+    NS(ClContext)* SIXTRL_RESTRICT ctx, NS(buffer_size_t) const until_turn,
     NS(buffer_size_t) const out_particle_block_offset,
     int const kernel_id );
 
-SIXTRL_HOST_FN int NS(ClContext_track_element_by_element)(
+SIXTRL_EXTERN SIXTRL_HOST_FN int NS(ClContext_track_element_by_element)(
     NS(ClContext)* SIXTRL_RESTRICT ctx,
     NS(ClArgument)* SIXTRL_RESTRICT ptr_particles_arg,
     NS(ClArgument)* SIXTRL_RESTRICT ptr_beam_elements_arg,
@@ -340,7 +427,8 @@ SIXTRL_HOST_FN int NS(ClContext_track_element_by_element)(
     NS(buffer_size_t) const until_turn,
     NS(buffer_size_t) const out_particle_block_offset );
 
-SIXTRL_HOST_FN int NS(ClContext_track_element_by_element_with_kernel_id)(
+SIXTRL_EXTERN SIXTRL_HOST_FN int
+NS(ClContext_track_element_by_element_with_kernel_id)(
     NS(ClContext)* SIXTRL_RESTRICT ctx,
     NS(ClArgument)* SIXTRL_RESTRICT ptr_particles_arg,
     NS(ClArgument)* SIXTRL_RESTRICT ptr_beam_elements_arg,
@@ -350,26 +438,30 @@ SIXTRL_HOST_FN int NS(ClContext_track_element_by_element_with_kernel_id)(
     int const tracking_kernel_id );
 
 /* ------------------------------------------------------------------------- */
-//
-SIXTRL_HOST_FN bool NS(ClContext_has_assign_beam_monitor_out_buffer_kernel)(
+
+SIXTRL_EXTERN SIXTRL_HOST_FN bool
+NS(ClContext_has_assign_beam_monitor_out_buffer_kernel)(
     const NS(ClContext) *const SIXTRL_RESTRICT ctx );
 
-SIXTRL_HOST_FN int NS(ClContext_get_assign_beam_monitor_out_buffer_kernel_id)(
+SIXTRL_EXTERN SIXTRL_HOST_FN int
+NS(ClContext_get_assign_beam_monitor_out_buffer_kernel_id)(
     const NS(ClContext) *const SIXTRL_RESTRICT ctx );
 
-SIXTRL_HOST_FN bool NS(ClContext_set_assign_beam_monitor_out_buffer_kernel_id)(
+SIXTRL_EXTERN SIXTRL_HOST_FN bool
+NS(ClContext_set_assign_beam_monitor_out_buffer_kernel_id)(
     NS(ClContext)* SIXTRL_RESTRICT ctx, int const assign_kernel_id );
 
 /* - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - */
 
-SIXTRL_HOST_FN int NS(ClContext_assign_beam_monitor_out_buffer)(
+SIXTRL_EXTERN SIXTRL_HOST_FN int NS(ClContext_assign_beam_monitor_out_buffer)(
     NS(ClContext)*  SIXTRL_RESTRICT ctx,
     NS(ClArgument)* SIXTRL_RESTRICT beam_elements_arg,
     NS(ClArgument)* SIXTRL_RESTRICT out_buffer,
     NS(buffer_size_t) const min_turn_id,
     NS(buffer_size_t) const out_particle_block_offset );
 
-SIXTRL_HOST_FN int NS(ClContext_assign_beam_monitor_out_buffer_with_kernel_id)(
+SIXTRL_EXTERN SIXTRL_HOST_FN int
+NS(ClContext_assign_beam_monitor_out_buffer_with_kernel_id)(
     NS(ClContext)*  SIXTRL_RESTRICT ctx,
     NS(ClArgument)* SIXTRL_RESTRICT beam_elements_arg,
     NS(ClArgument)* SIXTRL_RESTRICT out_buffer,
@@ -379,47 +471,53 @@ SIXTRL_HOST_FN int NS(ClContext_assign_beam_monitor_out_buffer_with_kernel_id)(
 
 /* - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - */
 
-SIXTRL_HOST_FN bool NS(ClContext_has_clear_beam_monitor_out_assignment_kernel)(
+SIXTRL_EXTERN SIXTRL_HOST_FN bool
+NS(ClContext_has_clear_beam_monitor_out_assignment_kernel)(
     const NS(ClContext) *const SIXTRL_RESTRICT ctx );
 
-SIXTRL_HOST_FN int NS(ClContext_get_clear_beam_monitor_out_assignment_kernel_id)(
+SIXTRL_EXTERN SIXTRL_HOST_FN int
+NS(ClContext_get_clear_beam_monitor_out_assignment_kernel_id)(
     const NS(ClContext) *const SIXTRL_RESTRICT ctx );
 
-SIXTRL_HOST_FN bool NS(ClContext_set_clear_beam_monitor_out_assignment_kernel_id)(
+SIXTRL_EXTERN SIXTRL_HOST_FN bool
+NS(ClContext_set_clear_beam_monitor_out_assignment_kernel_id)(
     NS(ClContext)* SIXTRL_RESTRICT ctx, int const kernel_id );
 
 /* - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - */
 
-SIXTRL_HOST_FN int NS(ClContext_clear_beam_monitor_out_assignment)(
+SIXTRL_EXTERN SIXTRL_HOST_FN int
+NS(ClContext_clear_beam_monitor_out_assignment)(
     NS(ClContext)*  SIXTRL_RESTRICT context,
     NS(ClArgument)* SIXTRL_RESTRICT beam_elements_arg );
 
-SIXTRL_HOST_FN int NS(ClContext_clear_beam_monitor_out_assignment_with_kernel)(
+SIXTRL_EXTERN SIXTRL_HOST_FN int
+NS(ClContext_clear_beam_monitor_out_assignment_with_kernel)(
     NS(ClContext)*  SIXTRL_RESTRICT context,
-    NS(ClArgument)* SIXTRL_RESTRICT beam_elements_arg,
-    int const kernel_id );
+    NS(ClArgument)* SIXTRL_RESTRICT beam_elements_arg, int const kernel_id );
 
 /* ------------------------------------------------------------------------- */
 
-SIXTRL_HOST_FN bool NS(ClContext_uses_optimized_tracking_by_default)(
+SIXTRL_EXTERN SIXTRL_HOST_FN bool
+NS(ClContext_uses_optimized_tracking_by_default)(
     const NS(ClContext) *const SIXTRL_RESTRICT ctx );
 
-SIXTRL_HOST_FN void NS(ClContext_enable_optimized_tracking_by_default)(
+SIXTRL_EXTERN SIXTRL_HOST_FN void
+NS(ClContext_enable_optimized_tracking_by_default)(
     NS(ClContext)* SIXTRL_RESTRICT ctx );
 
-SIXTRL_HOST_FN void NS(ClContext_disable_optimized_tracking_by_default)(
+SIXTRL_EXTERN SIXTRL_HOST_FN void
+NS(ClContext_disable_optimized_tracking_by_default)(
     NS(ClContext)* SIXTRL_RESTRICT ctx );
 
 /* ------------------------------------------------------------------------- */
 
-SIXTRL_HOST_FN bool NS(ClContext_is_beam_beam_tracking_enabled)(
+SIXTRL_EXTERN SIXTRL_HOST_FN bool NS(ClContext_is_beam_beam_tracking_enabled)(
     const NS(ClContext) *const SIXTRL_RESTRICT ctx );
 
-
-SIXTRL_HOST_FN void NS(ClContext_enable_beam_beam_tracking)(
+SIXTRL_EXTERN SIXTRL_HOST_FN void NS(ClContext_enable_beam_beam_tracking)(
     NS(ClContext)* SIXTRL_RESTRICT ctx );
 
-SIXTRL_HOST_FN void NS(ClContext_disable_beam_beam_tracking)(
+SIXTRL_EXTERN SIXTRL_HOST_FN void NS(ClContext_disable_beam_beam_tracking)(
     NS(ClContext)* SIXTRL_RESTRICT ctx );
 
 

--- a/sixtracklib/opencl/internal/base_context.cpp
+++ b/sixtracklib/opencl/internal/base_context.cpp
@@ -1046,27 +1046,39 @@ namespace SIXTRL_CXX_NAMESPACE
                 this->m_kernel_data.back().m_kernel_name = kernel_name;
                 this->m_kernel_data.back().m_program_id  = program_id;
 
-                this->m_kernel_data.back().resetArguments(
-                    kernel.getInfo< CL_KERNEL_NUM_ARGS >() );
-
                 cl::Device& selected_device = this->m_available_devices.at(
                     this->m_selected_node_index );
+
+                size_type const num_kernel_args =
+                    kernel.getInfo< CL_KERNEL_NUM_ARGS >();
+
+                size_type const max_work_group_size = kernel.getWorkGroupInfo<
+                    CL_KERNEL_WORK_GROUP_SIZE >( selected_device );
+
+                size_type const pref_work_group_size = kernel.getWorkGroupInfo<
+                    CL_KERNEL_PREFERRED_WORK_GROUP_SIZE_MULTIPLE >(
+                        selected_device );
+
+                size_type const loc_mem_size = kernel.getWorkGroupInfo<
+                    CL_KERNEL_LOCAL_MEM_SIZE >( selected_device );
+
+                SIXTRL_ASSERT( num_kernel_args  >= size_type{  0 } );
+                SIXTRL_ASSERT( num_kernel_args  <  size_type{ 32 } );
+                SIXTRL_ASSERT( pref_work_group_size > size_type{ 0 } );
+                SIXTRL_ASSERT( max_work_group_size  >= pref_work_group_size );
+                SIXTRL_ASSERT( max_work_group_size  <= size_type{ 65535 } );
+
+                this->m_kernel_data.back().resetArguments( num_kernel_args );
 
                 this->m_kernel_data.back().m_work_group_size = size_type{ 0 };
 
                 this->m_kernel_data.back().m_max_work_group_size =
-                    kernel.getWorkGroupInfo< CL_KERNEL_WORK_GROUP_SIZE >(
-                        selected_device );
+                    max_work_group_size;
 
                 this->m_kernel_data.back().m_preferred_work_group_multiple =
-                    kernel.getWorkGroupInfo<
-                         CL_KERNEL_PREFERRED_WORK_GROUP_SIZE_MULTIPLE >(
-                             selected_device );
+                    pref_work_group_size;
 
-                this->m_kernel_data.back().m_local_mem_size =
-                    kernel.getWorkGroupInfo< CL_KERNEL_LOCAL_MEM_SIZE >(
-                        selected_device );
-
+                this->m_kernel_data.back().m_local_mem_size = loc_mem_size;
                 program_data.m_kernels.push_back( kernel_id );
             }
         }

--- a/sixtracklib/opencl/internal/base_context.h
+++ b/sixtracklib/opencl/internal/base_context.h
@@ -412,6 +412,7 @@ namespace SIXTRL_CXX_NAMESPACE
             void resetArguments( size_type const nargs )
             {
                 using _this_t = ClContextBase;
+                SIXTRL_ASSERT( nargs <= size_type{ 64 } );
 
                 this->m_arguments.clear();
                 this->m_arg_types.clear();

--- a/sixtracklib/opencl/internal/context.cpp
+++ b/sixtracklib/opencl/internal/context.cpp
@@ -34,10 +34,12 @@ namespace SIXTRL_CXX_NAMESPACE
         m_track_until_turn_program_id( ClContext::program_id_t{ -1 } ),
         m_track_single_turn_program_id( ClContext::program_id_t{ -1 } ),
         m_track_elem_by_elem_program_id( ClContext::program_id_t{ -1 } ),
+        m_track_line_program_id( ClContext::program_id_t{ -1 } ),
         m_assign_be_mon_out_buffer_program_id( ClContext::program_id_t{ -1 } ),
         m_clear_be_mon_program_id( ClContext::program_id_t{ -1 } ),
         m_track_single_turn_kernel_id( ClContext::kernel_id_t{ -1 } ),
         m_track_elem_by_elem_kernel_id( ClContext::kernel_id_t{ -1 } ),
+        m_track_line_kernel_id( ClContext::kernel_id_t{ -1 } ),
         m_assign_be_mon_out_buffer_kernel_id( ClContext::kernel_id_t{ -1 } ),
         m_clear_be_mon_kernel_id( ClContext::kernel_id_t{ -1 } ),
         m_use_optimized_tracking( true ),
@@ -53,10 +55,12 @@ namespace SIXTRL_CXX_NAMESPACE
         m_track_until_turn_program_id( ClContext::program_id_t{ -1 } ),
         m_track_single_turn_program_id( ClContext::program_id_t{ -1 } ),
         m_track_elem_by_elem_program_id( ClContext::program_id_t{ -1 } ),
+        m_track_line_program_id( ClContext::program_id_t{ -1 } ),
         m_assign_be_mon_out_buffer_program_id( ClContext::program_id_t{ -1 } ),
         m_clear_be_mon_program_id( ClContext::program_id_t{ -1 } ),
         m_track_single_turn_kernel_id( ClContext::kernel_id_t{ -1 } ),
         m_track_elem_by_elem_kernel_id( ClContext::kernel_id_t{ -1 } ),
+        m_track_line_kernel_id( ClContext::kernel_id_t{ -1 } ),
         m_assign_be_mon_out_buffer_kernel_id( ClContext::kernel_id_t{ -1 } ),
         m_clear_be_mon_kernel_id( ClContext::kernel_id_t{ -1 } ),
         m_use_optimized_tracking( true ),
@@ -86,10 +90,12 @@ namespace SIXTRL_CXX_NAMESPACE
         m_track_until_turn_program_id( ClContext::program_id_t{ -1 } ),
         m_track_single_turn_program_id( ClContext::program_id_t{ -1 } ),
         m_track_elem_by_elem_program_id( ClContext::program_id_t{ -1 } ),
+        m_track_line_program_id( ClContext::program_id_t{ -1 } ),
         m_assign_be_mon_out_buffer_program_id( ClContext::program_id_t{ -1 } ),
         m_clear_be_mon_program_id( ClContext::program_id_t{ -1 } ),
         m_track_single_turn_kernel_id( ClContext::kernel_id_t{ -1 } ),
         m_track_elem_by_elem_kernel_id( ClContext::kernel_id_t{ -1 } ),
+        m_track_line_kernel_id( ClContext::kernel_id_t{ -1 } ),
         m_assign_be_mon_out_buffer_kernel_id( ClContext::kernel_id_t{ -1 } ),
         m_clear_be_mon_kernel_id( ClContext::kernel_id_t{ -1 } ),
         m_use_optimized_tracking( true ),
@@ -120,10 +126,12 @@ namespace SIXTRL_CXX_NAMESPACE
         m_track_until_turn_program_id( ClContext::program_id_t{ -1 } ),
         m_track_single_turn_program_id( ClContext::program_id_t{ -1 } ),
         m_track_elem_by_elem_program_id( ClContext::program_id_t{ -1 } ),
+        m_track_line_program_id( ClContext::program_id_t{ -1 } ),
         m_assign_be_mon_out_buffer_program_id( ClContext::program_id_t{ -1 } ),
         m_clear_be_mon_program_id( ClContext::program_id_t{ -1 } ),
         m_track_single_turn_kernel_id( ClContext::kernel_id_t{ -1 } ),
         m_track_elem_by_elem_kernel_id( ClContext::kernel_id_t{ -1 } ),
+        m_track_line_kernel_id( ClContext::kernel_id_t{ -1 } ),
         m_assign_be_mon_out_buffer_kernel_id( ClContext::kernel_id_t{ -1 } ),
         m_clear_be_mon_kernel_id( ClContext::kernel_id_t{ -1 } ),
         m_use_optimized_tracking( true ),
@@ -168,10 +176,12 @@ namespace SIXTRL_CXX_NAMESPACE
         m_track_until_turn_program_id( ClContext::program_id_t{ -1 } ),
         m_track_single_turn_program_id( ClContext::program_id_t{ -1 } ),
         m_track_elem_by_elem_program_id( ClContext::program_id_t{ -1 } ),
+        m_track_line_program_id( ClContext::program_id_t{ -1 } ),
         m_assign_be_mon_out_buffer_program_id( ClContext::program_id_t{ -1 } ),
         m_clear_be_mon_program_id( ClContext::program_id_t{ -1 } ),
         m_track_single_turn_kernel_id( ClContext::kernel_id_t{ -1 } ),
         m_track_elem_by_elem_kernel_id( ClContext::kernel_id_t{ -1 } ),
+        m_track_line_kernel_id( ClContext::kernel_id_t{ -1 } ),
         m_assign_be_mon_out_buffer_kernel_id( ClContext::kernel_id_t{ -1 } ),
         m_clear_be_mon_kernel_id( ClContext::kernel_id_t{ -1 } ),
         m_use_optimized_tracking( true ),
@@ -200,7 +210,8 @@ namespace SIXTRL_CXX_NAMESPACE
     }
 
     bool ClContext::assignParticleArg(
-        ClArgument& SIXTRL_RESTRICT_REF particles_arg )
+        ClArgument& SIXTRL_RESTRICT_REF particles_arg,
+        ClContext::size_type const particle_set_index )
     {
         bool success = false;
 
@@ -242,6 +253,15 @@ namespace SIXTRL_CXX_NAMESPACE
 
                 success &= ( this->kernelNumArgs( kernel_id ) >= size_t{3u} );
                 this->assignKernelArgument( kernel_id, 0u, particles_arg );
+            }
+
+            if( this->hasLineTrackingKernel() )
+            {
+                kernel_id_t const kernel_id = this->lineTrackingKernelId();
+                success &= ( this->kernelNumArgs( kernel_id ) >= size_t{ 6u } );
+                this->assignKernelArgument( kernel_id, 0u, particles_arg );
+                this->assignKernelArgumentValue( kernel_id, 1u,
+                                                 particle_set_index );
             }
         }
 
@@ -287,6 +307,14 @@ namespace SIXTRL_CXX_NAMESPACE
 
                 success &= ( this->kernelNumArgs( kernel_id ) >= size_t{3u} );
                 this->assignKernelArgument( kernel_id, 1u, beam_elem_arg );
+            }
+
+
+            if( this->hasLineTrackingKernel() )
+            {
+                kernel_id_t const kernel_id = this->lineTrackingKernelId();
+                success &= ( this->kernelNumArgs( kernel_id ) >= size_t{ 6u } );
+                this->assignKernelArgument( kernel_id, 2u, beam_elem_arg );
             }
 
             if( this->hasAssignBeamMonitorIoBufferKernel() )
@@ -422,9 +450,7 @@ namespace SIXTRL_CXX_NAMESPACE
 
         if( this->hasSingleTurnTrackingKernel() )
         {
-            kernel_id_t const kernel_id =
-                this->singleTurnTackingKernelId();
-
+            kernel_id_t const kernel_id = this->singleTurnTackingKernelId();
             size_t const num_kernel_args = this->kernelNumArgs( kernel_id );
             success &= ( num_kernel_args >= size_t{ 3u } );
 
@@ -432,6 +458,18 @@ namespace SIXTRL_CXX_NAMESPACE
             {
                 this->assignKernelArgumentClBuffer(
                     kernel_id, 3u, cl_success_flag_buffer );
+            }
+        }
+
+        if( this->hasLineTrackingKernel() )
+        {
+            kernel_id_t const kernel_id = this->lineTrackingKernelId();
+            success &= ( this->kernelNumArgs( kernel_id ) >= 6u );
+
+            if( this->kernelNumArgs( kernel_id ) > 6u )
+            {
+                this->assignKernelArgumentClBuffer(
+                    kernel_id, 6u, cl_success_flag_buffer );
             }
         }
 
@@ -585,6 +623,171 @@ namespace SIXTRL_CXX_NAMESPACE
             ? 0 : -1;
 
         if( ( success == 0 ) && ( num_kernel_args > 3u ) )
+        {
+            cl::CommandQueue* ptr_queue = this->openClQueue();
+            SIXTRL_ASSERT( ptr_queue != nullptr );
+
+            int32_t success_flag = int32_t{ -1 };
+            cl_int cl_ret = ptr_queue->enqueueReadBuffer(
+                this->internalSuccessFlagBuffer(), CL_TRUE, 0,
+                sizeof( success_flag ), &success_flag );
+
+            if( cl_ret == CL_SUCCESS )
+            {
+                success = ( int )success_flag;
+            }
+
+            ptr_queue->finish();
+        }
+
+        return success;
+    }
+
+    /* - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - */
+
+    bool ClContext::hasLineTrackingKernel() const SIXTRL_NOEXCEPT
+    {
+        return ( ( this->hasSelectedNode() ) &&
+                 ( this->m_track_single_turn_kernel_id >= kernel_id_t{ 0 } ) &&
+                 ( static_cast< size_type >(
+                     this->m_track_single_turn_kernel_id ) <
+                         this->numAvailableKernels() ) );
+    }
+
+    ClContext::kernel_id_t
+    ClContext::lineTrackingKernelId() const SIXTRL_NOEXCEPT
+    {
+        return ( this->hasTrackingKernel() )
+            ? this->m_track_until_turn_kernel_id
+            : ClContext::kernel_id_t{ -1 };
+    }
+
+    bool ClContext::setTrackLineKernelId(
+        ClContext::kernel_id_t const kernel_id )
+    {
+        bool success = false;
+
+        if( ( this->hasSelectedNode() ) &&
+            ( kernel_id >= kernel_id_t{ 0 } ) &&
+            ( static_cast< size_type >( kernel_id ) <
+              this->numAvailableKernels() ) )
+        {
+            program_id_t const program_id =
+                this->programIdByKernelId( kernel_id );
+
+            if( ( program_id >= program_id_t{ 0 } ) &&
+                ( static_cast< size_type >( program_id ) <
+                    this->numAvailablePrograms() ) )
+            {
+                this->m_track_single_turn_kernel_id  = kernel_id;
+                this->m_track_single_turn_program_id = program_id;
+                success = true;
+            }
+        }
+
+        return success;
+    }
+
+    int ClContext::trackLine(
+        ClContext::size_type const line_begin_idx,
+        ClContext::size_type const line_end_idx, bool const finish_turn )
+    {
+        return this->trackLine( line_begin_idx, line_end_idx,
+            finish_turn, this->m_track_single_turn_kernel_id );
+    }
+
+    int ClContext::trackLine(
+        ClContext::size_type const line_begin_idx, size_type line_end_idx,
+        bool const finish_turn, kernel_id_t const kernel_id )
+    {
+        int status = int{ -1 };
+
+        if( ( this->hasSelectedNode() ) && ( kernel_id >= kernel_id_t{ 0 } ) &&
+            ( static_cast< size_type >( kernel_id ) <=
+                this->numAvailableKernels() ) )
+        {
+            uint64_t const finish_turn_value = ( finish_turn )
+                ? uint64_t{ 1 } : uint64_t{ 0 };
+
+            this->assignKernelArgumentValue( kernel_id, 3u, line_begin_idx );
+            this->assignKernelArgumentValue( kernel_id, 4u, line_end_idx );
+            this->assignKernelArgumentValue( kernel_id, 5u, finish_turn_value );
+
+            size_type const nitems = this->lastExecNumWorkItems( kernel_id );
+            size_type const grsize = this->lastExecWorkGroupSize( kernel_id );
+            status = ( this->runKernel( kernel_id, nitems, grsize ) ) ? 0 : -1;
+        }
+
+        return status;
+    }
+
+    int ClContext::trackLine(
+        ClArgument& SIXTRL_RESTRICT_REF particles_arg,
+        ClContext::size_type const particle_set_index,
+        ClArgument& SIXTRL_RESTRICT_REF beam_elements_arg,
+        ClContext::size_type const line_begin_idx,
+        ClContext::size_type const line_end_idx,
+        bool const finish_turn )
+    {
+        return this->trackLine( particles_arg, particle_set_index,
+            beam_elements_arg, line_begin_idx, line_end_idx, finish_turn,
+                this->m_track_single_turn_kernel_id );
+    }
+
+    int ClContext::trackLine(
+        ClArgument& SIXTRL_RESTRICT_REF particles_arg,
+        ClContext::size_type const particle_set_index,
+        ClArgument& SIXTRL_RESTRICT_REF beam_elements_arg,
+        ClContext::size_type const line_begin_idx,
+        ClContext::size_type const line_end_idx,
+        bool const finish_turn, ClContext::kernel_id_t const kernel_id )
+    {
+        int success = -1;
+
+        SIXTRL_ASSERT( this->hasSelectedNode() );
+        SIXTRL_ASSERT( ( kernel_id >= kernel_id_t{ 0 } ) &&
+            ( static_cast< size_type >( kernel_id ) <
+                this->numAvailableKernels() ) );
+
+        SIXTRL_ASSERT( particles_arg.usesCObjectBuffer() );
+        NS(Buffer)* particles_buffer = particles_arg.ptrCObjectBuffer();
+        SIXTRL_ASSERT( !NS(Buffer_needs_remapping)( particles_buffer ) );
+
+        const ::NS(Particles) *const particles =
+            ::NS(Particles_buffer_get_const_particles)(
+                particles_buffer, particle_set_index );
+        SIXTRL_ASSERT( particles != nullptr );
+
+        size_type const num_particles =
+            ::NS(Particles_get_num_of_particles)( particles );
+        SIXTRL_ASSERT( num_particles > size_type{ 0 } );
+
+        SIXTRL_ASSERT( beam_elements_arg.usesCObjectBuffer() );
+        SIXTRL_ASSERT( !NS(Buffer_needs_remapping)(
+            beam_elements_arg.ptrCObjectBuffer() ) );
+
+        size_type const num_kernel_args = this->kernelNumArgs( kernel_id );
+        SIXTRL_ASSERT(  num_kernel_args >= 6u );
+
+        uint64_t const finish_turn_value = ( finish_turn )
+            ? uint64_t{ 1 } : uint64_t{ 0 };
+
+        this->assignKernelArgument( kernel_id, 0u, particles_arg );
+        this->assignKernelArgumentValue( kernel_id, 1u, particle_set_index );
+        this->assignKernelArgument( kernel_id, 2u, beam_elements_arg );
+        this->assignKernelArgumentValue( kernel_id, 3u, line_begin_idx );
+        this->assignKernelArgumentValue( kernel_id, 4u, line_end_idx );
+        this->assignKernelArgumentValue( kernel_id, 5u, finish_turn_value );
+
+        if( num_kernel_args > 6u )
+        {
+            this->assignKernelArgumentClBuffer( kernel_id, 6u,
+                this->internalSuccessFlagBuffer() );
+        }
+
+        success = ( this->runKernel( kernel_id, num_particles ) ) ? 0 : -1;
+
+        if( ( success == 0 ) && ( num_kernel_args > 6u ) )
         {
             cl::CommandQueue* ptr_queue = this->openClQueue();
             SIXTRL_ASSERT( ptr_queue != nullptr );
@@ -1375,12 +1578,14 @@ namespace SIXTRL_CXX_NAMESPACE
                 this->m_track_until_turn_program_id   = track_program_id;
                 this->m_track_single_turn_program_id  = track_program_id;
                 this->m_track_elem_by_elem_program_id = track_program_id;
+                this->m_track_line_program_id         = track_program_id;
             }
             else
             {
                 this->m_track_until_turn_program_id   = track_optimized_program_id;
                 this->m_track_single_turn_program_id  = track_optimized_program_id;
                 this->m_track_elem_by_elem_program_id = track_optimized_program_id;
+                this->m_track_line_program_id         = track_optimized_program_id;
             }
 
             this->m_assign_be_mon_out_buffer_program_id = out_buffer_program_id;
@@ -1485,6 +1690,34 @@ namespace SIXTRL_CXX_NAMESPACE
             }
 
             if( ( success ) &&
+                ( this->m_track_line_program_id >= program_id_t{ 0 } ) &&
+                ( this->m_track_line_program_id <  max_program_id ) )
+            {
+                std::string kernel_name( SIXTRL_C99_NAMESPACE_PREFIX_STR );
+                kernel_name += "Track_particles_line";
+
+                if( this->useOptimizedTrackingByDefault() )
+                {
+                    kernel_name += "_opt_pp";
+                }
+
+                if( this->debugMode() )
+                {
+                    kernel_name += "_debug";
+                }
+
+                kernel_name += "_opencl";
+
+                kernel_id_t const kernel_id = this->enableKernel(
+                    kernel_name.c_str(), this->m_track_line_program_id );
+
+                if( kernel_id >= kernel_id_t{ 0 } )
+                {
+                    success = this->setTrackLineKernelId( kernel_id );
+                }
+            }
+
+            if( ( success ) &&
                 ( this->m_assign_be_mon_out_buffer_program_id >= program_id_t{ 0 } ) &&
                 ( this->m_assign_be_mon_out_buffer_program_id <  max_program_id ) )
             {
@@ -1572,41 +1805,41 @@ namespace SIXTRL_CXX_NAMESPACE
 
 /* ========================================================================= */
 
-SIXTRL_HOST_FN NS(ClContext)* NS(ClContext_create)()
+NS(ClContext)* NS(ClContext_create)()
 {
     return new SIXTRL_CXX_NAMESPACE::ClContext;
 }
 
-SIXTRL_HOST_FN NS(ClContext)* NS(ClContext_new)( const char* node_id_str )
+NS(ClContext)* NS(ClContext_new)( const char* node_id_str )
 {
     return new SIXTRL_CXX_NAMESPACE::ClContext( node_id_str, nullptr );
 }
 
-SIXTRL_HOST_FN void NS(ClContext_delete)( NS(ClContext)* SIXTRL_RESTRICT ctx )
+void NS(ClContext_delete)( NS(ClContext)* SIXTRL_RESTRICT ctx )
 {
     delete ctx;
 }
 
-SIXTRL_HOST_FN void NS(ClContext_clear)( NS(ClContext)* SIXTRL_RESTRICT ctx )
+void NS(ClContext_clear)( NS(ClContext)* SIXTRL_RESTRICT ctx )
 {
     if( ctx != nullptr ) ctx->clear();
     return;
 }
 
-SIXTRL_HOST_FN bool NS(ClContext_has_tracking_kernel)(
+bool NS(ClContext_has_tracking_kernel)(
     const NS(ClContext) *const SIXTRL_RESTRICT ctx )
 {
     return ( ctx != nullptr ) ? ctx->hasTrackingKernel() : false;
 }
 
 
-SIXTRL_HOST_FN int NS(ClContext_get_tracking_kernel_id)(
+int NS(ClContext_get_tracking_kernel_id)(
     const NS(ClContext) *const SIXTRL_RESTRICT ctx )
 {
     return ( ctx != nullptr ) ? ctx->trackingKernelId() : -1;
 }
 
-SIXTRL_HOST_FN bool NS(ClContext_set_tracking_kernel_id)(
+bool NS(ClContext_set_tracking_kernel_id)(
     NS(ClContext)* SIXTRL_RESTRICT ctx, int const tracking_kernel_id )
 {
     return ( ctx != nullptr )
@@ -1615,21 +1848,21 @@ SIXTRL_HOST_FN bool NS(ClContext_set_tracking_kernel_id)(
 
 /* ------------------------------------------------------------------------- */
 
-SIXTRL_HOST_FN int NS(ClContext_continue_tracking)(
+int NS(ClContext_continue_tracking)(
     NS(ClContext)* SIXTRL_RESTRICT ctx,
     NS(context_num_turns_t) const until_turn )
 {
     return ( ctx != nullptr ) ? ctx->track( until_turn ) : -1;
 }
 
-SIXTRL_HOST_FN int NS(ClContext_continue_tracking_with_kernel_id)(
+int NS(ClContext_continue_tracking_with_kernel_id)(
     NS(ClContext)* SIXTRL_RESTRICT ctx, int const track_kernel_id,
     NS(context_num_turns_t) const until_turn )
 {
     return ( ctx != nullptr ) ? ctx->track( until_turn, track_kernel_id ) : -1;
 }
 
-SIXTRL_HOST_FN int NS(ClContext_track)(
+int NS(ClContext_track)(
     NS(ClContext)* SIXTRL_RESTRICT ctx,
     NS(ClArgument)* SIXTRL_RESTRICT ptr_particles_arg,
     NS(ClArgument)* SIXTRL_RESTRICT ptr_beam_elements_arg,
@@ -1641,7 +1874,7 @@ SIXTRL_HOST_FN int NS(ClContext_track)(
         : -1;
 }
 
-SIXTRL_HOST_FN int NS(ClContext_track_with_kernel_id)(
+int NS(ClContext_track_with_kernel_id)(
     NS(ClContext)* SIXTRL_RESTRICT ctx,
     NS(ClArgument)* SIXTRL_RESTRICT ptr_particles_arg,
     NS(ClArgument)* SIXTRL_RESTRICT ptr_beam_elements_arg,
@@ -1656,19 +1889,98 @@ SIXTRL_HOST_FN int NS(ClContext_track_with_kernel_id)(
 
 /* ------------------------------------------------------------------------- */
 
-SIXTRL_HOST_FN bool NS(ClContext_has_single_turn_tracking_kernel)(
+bool NS(ClContext_has_line_tracking_kernel)(
+    const NS(ClContext) *const SIXTRL_RESTRICT ctx )
+{
+    return ( ctx != nullptr ) ? ctx->hasLineTrackingKernel() : false;
+}
+
+int NS(ClContext_get_line_tracking_kernel_id)(
+    const NS(ClContext) *const SIXTRL_RESTRICT ctx )
+{
+    SIXTRL_ASSERT( ctx != nullptr );
+    return ctx->lineTrackingKernelId();
+}
+
+bool NS(ClContext_set_line_tracking_kernel_id)(
+    NS(ClContext)* SIXTRL_RESTRICT ctx, int const kernel_id )
+{
+    return ( ctx != nullptr ) ? ctx->setTrackLineKernelId( kernel_id ) : false;
+}
+
+/* - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - */
+
+int NS(ClContext_continue_line_tracking)( NS(ClContext)* SIXTRL_RESTRICT ctx,
+    NS(buffer_size_t) const line_begin_idx,
+    NS(buffer_size_t) const line_end_idx, bool const finish_turn )
+{
+    SIXTRL_ASSERT( ctx != nullptr );
+    return ctx->trackLine( line_begin_idx, line_end_idx, finish_turn,
+        ctx->lineTrackingKernelId() );
+}
+
+int NS(ClContext_continue_line_tracking_with_kernel_id)(
+    NS(ClContext)* SIXTRL_RESTRICT ctx,
+    NS(buffer_size_t) const line_begin_idx,
+    NS(buffer_size_t) const line_end_idx,
+    bool const finish_turn, int const line_tracking_kernel_id )
+{
+    SIXTRL_ASSERT( ctx != nullptr );
+    return ctx->trackLine( line_begin_idx, line_end_idx, finish_turn,
+                           line_tracking_kernel_id );
+}
+
+int NS(ClContext_track_line)(
+    NS(ClContext)* SIXTRL_RESTRICT ctx,
+    NS(ClArgument)* SIXTRL_RESTRICT ptr_particles_arg,
+    NS(buffer_size_t) const particle_set_index,
+    NS(ClArgument)* SIXTRL_RESTRICT ptr_beam_elements_arg,
+    NS(buffer_size_t) const line_begin_idx,
+    NS(buffer_size_t) const line_end_idx, bool const finish_turn )
+{
+    SIXTRL_ASSERT( ctx != nullptr );
+    SIXTRL_ASSERT( ptr_particles_arg != SIXTRL_NULLPTR );
+    SIXTRL_ASSERT( ptr_beam_elements_arg != SIXTRL_NULLPTR );
+    return ctx->trackLine( *ptr_particles_arg, particle_set_index,
+        *ptr_beam_elements_arg, line_begin_idx, line_end_idx, finish_turn,
+            ctx->lineTrackingKernelId() );
+}
+
+int NS(ClContext_track_line_with_kernel_id)(
+    NS(ClContext)* SIXTRL_RESTRICT ctx,
+    NS(ClArgument)* SIXTRL_RESTRICT ptr_particles_arg,
+    NS(buffer_size_t) const particle_set_index,
+    NS(ClArgument)* SIXTRL_RESTRICT ptr_beam_elements_arg,
+    NS(buffer_size_t) const line_begin_idx,
+    NS(buffer_size_t) const line_end_idx, bool const finish_turn,
+    int const line_tracking_kernel_id )
+{
+    SIXTRL_ASSERT( ctx != nullptr );
+    SIXTRL_ASSERT( ctx != nullptr );
+    SIXTRL_ASSERT( ptr_particles_arg != SIXTRL_NULLPTR );
+    SIXTRL_ASSERT( ptr_beam_elements_arg != SIXTRL_NULLPTR );
+
+    return ctx->trackLine( *ptr_particles_arg, particle_set_index,
+        *ptr_beam_elements_arg, line_begin_idx, line_end_idx, finish_turn,
+            line_tracking_kernel_id );
+}
+
+
+/* ------------------------------------------------------------------------- */
+
+bool NS(ClContext_has_single_turn_tracking_kernel)(
     const NS(ClContext) *const SIXTRL_RESTRICT ctx )
 {
     return ( ctx != nullptr ) ? ctx->hasSingleTurnTrackingKernel() : false;
 }
 
-SIXTRL_HOST_FN int NS(ClContext_get_single_turn_tracking_kernel_id)(
+int NS(ClContext_get_single_turn_tracking_kernel_id)(
     const NS(ClContext) *const SIXTRL_RESTRICT ctx )
 {
     return ( ctx != nullptr ) ? ctx->singleTurnTackingKernelId() : -1;
 }
 
-SIXTRL_HOST_FN bool NS(ClContext_set_single_turn_tracking_kernel_id)(
+bool NS(ClContext_set_single_turn_tracking_kernel_id)(
     NS(ClContext)* SIXTRL_RESTRICT ctx, int const tracking_kernel_id )
 {
     return ( ctx != nullptr )
@@ -1677,19 +1989,19 @@ SIXTRL_HOST_FN bool NS(ClContext_set_single_turn_tracking_kernel_id)(
 
 /* - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - */
 
-SIXTRL_HOST_FN int NS(ClContext_continue_tracking_single_turn)(
+int NS(ClContext_continue_tracking_single_turn)(
     NS(ClContext)* SIXTRL_RESTRICT ctx )
 {
     return ( ctx != nullptr ) ? ctx->trackSingleTurn() : -1;
 }
 
-SIXTRL_HOST_FN int NS(ClContext_continue_tracking_single_turn_with_kernel_id)(
+int NS(ClContext_continue_tracking_single_turn_with_kernel_id)(
     NS(ClContext)* SIXTRL_RESTRICT ctx, int const kernel_id )
 {
     return ( ctx != nullptr ) ? ctx->trackSingleTurn( kernel_id ) : -1;
 }
 
-SIXTRL_HOST_FN int NS(ClContext_track_single_turn)(
+int NS(ClContext_track_single_turn)(
     NS(ClContext)* SIXTRL_RESTRICT ctx,
     NS(ClArgument)* SIXTRL_RESTRICT ptr_particles_arg,
     NS(ClArgument)* SIXTRL_RESTRICT ptr_beam_elements_arg )
@@ -1700,7 +2012,7 @@ SIXTRL_HOST_FN int NS(ClContext_track_single_turn)(
         : -1;
 }
 
-SIXTRL_HOST_FN int NS(ClContext_track_single_turn_with_kernel_id)(
+int NS(ClContext_track_single_turn_with_kernel_id)(
     NS(ClContext)* SIXTRL_RESTRICT ctx,
     NS(ClArgument)* SIXTRL_RESTRICT ptr_particles_arg,
     NS(ClArgument)* SIXTRL_RESTRICT ptr_beam_elements_arg,
@@ -1714,19 +2026,19 @@ SIXTRL_HOST_FN int NS(ClContext_track_single_turn_with_kernel_id)(
 
 /* ------------------------------------------------------------------------- */
 
-SIXTRL_HOST_FN bool NS(ClContext_has_element_by_element_tracking_kernel)(
+bool NS(ClContext_has_element_by_element_tracking_kernel)(
     const NS(ClContext) *const SIXTRL_RESTRICT ctx )
 {
     return ( ctx != nullptr ) ? ctx->hasElementByElementTrackingKernel() : false;
 }
 
-SIXTRL_HOST_FN int NS(ClContext_get_element_by_element_tracking_kernel_id)(
+int NS(ClContext_get_element_by_element_tracking_kernel_id)(
     const NS(ClContext) *const SIXTRL_RESTRICT ctx )
 {
     return (ctx != nullptr ) ? ctx->elementByElementTrackingKernelId() : -1;
 }
 
-SIXTRL_HOST_FN bool NS(ClContext_set_element_by_element_tracking_kernel_id)(
+bool NS(ClContext_set_element_by_element_tracking_kernel_id)(
     NS(ClContext)* SIXTRL_RESTRICT ctx, int const tracking_kernel_id )
 {
     return ( ctx != nullptr )
@@ -1736,7 +2048,7 @@ SIXTRL_HOST_FN bool NS(ClContext_set_element_by_element_tracking_kernel_id)(
 
 /* - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - */
 
-SIXTRL_HOST_FN int NS(ClContext_continue_tracking_element_by_element)(
+int NS(ClContext_continue_tracking_element_by_element)(
     NS(ClContext)* SIXTRL_RESTRICT ctx,
     NS(buffer_size_t) const until_turn,
     NS(buffer_size_t) const out_buffer_index_offset )
@@ -1746,7 +2058,7 @@ SIXTRL_HOST_FN int NS(ClContext_continue_tracking_element_by_element)(
         : -1;
 }
 
-SIXTRL_HOST_FN int NS(ClContext_continue_tracking_element_by_element_with_kernel_id)(
+int NS(ClContext_continue_tracking_element_by_element_with_kernel_id)(
     NS(ClContext)* SIXTRL_RESTRICT ctx,
     NS(buffer_size_t) const until_turn,
     NS(buffer_size_t) const out_buffer_index_offset,
@@ -1758,7 +2070,7 @@ SIXTRL_HOST_FN int NS(ClContext_continue_tracking_element_by_element_with_kernel
         : -1;
 }
 
-SIXTRL_HOST_FN int NS(ClContext_track_element_by_element)(
+int NS(ClContext_track_element_by_element)(
     NS(ClContext)*  SIXTRL_RESTRICT ctx,
     NS(ClArgument)* SIXTRL_RESTRICT ptr_particles_arg,
     NS(ClArgument)* SIXTRL_RESTRICT ptr_beam_elements_arg,
@@ -1775,7 +2087,7 @@ SIXTRL_HOST_FN int NS(ClContext_track_element_by_element)(
         : -1;
 }
 
-SIXTRL_HOST_FN int NS(ClContext_track_element_by_element_with_kernel_id)(
+int NS(ClContext_track_element_by_element_with_kernel_id)(
     NS(ClContext)* SIXTRL_RESTRICT ctx,
     NS(ClArgument)* SIXTRL_RESTRICT ptr_particles_arg,
     NS(ClArgument)* SIXTRL_RESTRICT ptr_beam_elements_arg,
@@ -1796,19 +2108,19 @@ SIXTRL_HOST_FN int NS(ClContext_track_element_by_element_with_kernel_id)(
 
 /* ------------------------------------------------------------------------- */
 
-SIXTRL_HOST_FN bool NS(ClContext_has_assign_beam_monitor_out_buffer_kernel)(
+bool NS(ClContext_has_assign_beam_monitor_out_buffer_kernel)(
     const NS(ClContext) *const SIXTRL_RESTRICT ctx )
 {
     return (ctx != nullptr ) ? ctx->hasAssignBeamMonitorIoBufferKernel() : false;
 }
 
-SIXTRL_HOST_FN int NS(ClContext_get_assign_beam_monitor_out_buffer_kernel_id)(
+int NS(ClContext_get_assign_beam_monitor_out_buffer_kernel_id)(
     const NS(ClContext) *const SIXTRL_RESTRICT ctx )
 {
     return ( ctx != nullptr ) ? ctx->assignBeamMonitorIoBufferKernelId() : -1;
 }
 
-SIXTRL_HOST_FN bool NS(ClContext_set_assign_beam_monitor_out_buffer_kernel_id)(
+bool NS(ClContext_set_assign_beam_monitor_out_buffer_kernel_id)(
     NS(ClContext)* SIXTRL_RESTRICT ctx, int const assign_kernel_id )
 {
     return ( ctx != nullptr )
@@ -1818,7 +2130,7 @@ SIXTRL_HOST_FN bool NS(ClContext_set_assign_beam_monitor_out_buffer_kernel_id)(
 
 /* - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - */
 
-SIXTRL_HOST_FN int NS(ClContext_assign_beam_monitor_out_buffer)(
+int NS(ClContext_assign_beam_monitor_out_buffer)(
     NS(ClContext)*  SIXTRL_RESTRICT ctx,
     NS(ClArgument)* SIXTRL_RESTRICT ptr_beam_elements_arg,
     NS(ClArgument)* SIXTRL_RESTRICT ptr_out_buffer_arg,
@@ -1832,7 +2144,7 @@ SIXTRL_HOST_FN int NS(ClContext_assign_beam_monitor_out_buffer)(
         : -1;
 }
 
-SIXTRL_HOST_FN int NS(ClContext_assign_beam_monitor_out_buffer_with_kernel_id)(
+int NS(ClContext_assign_beam_monitor_out_buffer_with_kernel_id)(
     NS(ClContext)*  SIXTRL_RESTRICT ctx,
     NS(ClArgument)* SIXTRL_RESTRICT ptr_beam_elements_arg,
     NS(ClArgument)* SIXTRL_RESTRICT ptr_out_buffer_arg,
@@ -1848,7 +2160,7 @@ SIXTRL_HOST_FN int NS(ClContext_assign_beam_monitor_out_buffer_with_kernel_id)(
         : -1;
 }
 
-SIXTRL_HOST_FN bool NS(ClContext_has_clear_beam_monitor_out_assignment_kernel)(
+bool NS(ClContext_has_clear_beam_monitor_out_assignment_kernel)(
     const NS(ClContext) *const SIXTRL_RESTRICT ctx )
 {
     return ( ctx != nullptr )
@@ -1856,14 +2168,14 @@ SIXTRL_HOST_FN bool NS(ClContext_has_clear_beam_monitor_out_assignment_kernel)(
         : false;
 }
 
-SIXTRL_HOST_FN int NS(ClContext_get_clear_beam_monitor_out_assignment_kernel_id)(
+int NS(ClContext_get_clear_beam_monitor_out_assignment_kernel_id)(
     const NS(ClContext) *const SIXTRL_RESTRICT ctx )
 {
     return (ctx != nullptr )
         ? ctx->clearBeamMonitorIoBufferAssignmentKernelId() : -1;
 }
 
-SIXTRL_HOST_FN bool NS(ClContext_set_clear_beam_monitor_out_assignment_kernel_id)(
+bool NS(ClContext_set_clear_beam_monitor_out_assignment_kernel_id)(
     NS(ClContext)* SIXTRL_RESTRICT ctx, int const kernel_id )
 {
     bool success = false;
@@ -1878,7 +2190,7 @@ SIXTRL_HOST_FN bool NS(ClContext_set_clear_beam_monitor_out_assignment_kernel_id
 
 /* - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - */
 
-SIXTRL_HOST_FN int NS(ClContext_clear_beam_monitor_out_assignment)(
+int NS(ClContext_clear_beam_monitor_out_assignment)(
     NS(ClContext)*  SIXTRL_RESTRICT ctx,
     NS(ClArgument)* SIXTRL_RESTRICT beam_elements_arg )
 {
@@ -1887,7 +2199,7 @@ SIXTRL_HOST_FN int NS(ClContext_clear_beam_monitor_out_assignment)(
         : -1;
 }
 
-SIXTRL_HOST_FN int NS(ClContext_clear_beam_monitor_out_assignment_with_kernel)(
+int NS(ClContext_clear_beam_monitor_out_assignment_with_kernel)(
     NS(ClContext)*  SIXTRL_RESTRICT ctx,
     NS(ClArgument)* SIXTRL_RESTRICT beam_elements_arg,
     int const kernel_id )
@@ -1900,20 +2212,20 @@ SIXTRL_HOST_FN int NS(ClContext_clear_beam_monitor_out_assignment_with_kernel)(
 
 /* ------------------------------------------------------------------------- */
 
-SIXTRL_HOST_FN bool NS(ClContext_uses_optimized_tracking_by_default)(
+bool NS(ClContext_uses_optimized_tracking_by_default)(
     const NS(ClContext) *const SIXTRL_RESTRICT ctx )
 {
     return ( ctx != nullptr ) ? ctx->useOptimizedTrackingByDefault() : false;
 }
 
-SIXTRL_HOST_FN void NS(ClContext_enable_optimized_tracking_by_default)(
+void NS(ClContext_enable_optimized_tracking_by_default)(
     NS(ClContext)* SIXTRL_RESTRICT ctx )
 {
     if( ctx != nullptr ) ctx->enableOptimizedtrackingByDefault();
     return;
 }
 
-SIXTRL_HOST_FN void NS(ClContext_disable_optimized_tracking_by_default)(
+void NS(ClContext_disable_optimized_tracking_by_default)(
     NS(ClContext)* SIXTRL_RESTRICT ctx )
 {
     if( ctx != nullptr ) ctx->disableOptimizedTrackingByDefault();
@@ -1922,14 +2234,14 @@ SIXTRL_HOST_FN void NS(ClContext_disable_optimized_tracking_by_default)(
 
 /* ------------------------------------------------------------------------- */
 
-SIXTRL_HOST_FN bool NS(ClContext_is_beam_beam_tracking_enabled)(
+bool NS(ClContext_is_beam_beam_tracking_enabled)(
     const NS(ClContext) *const SIXTRL_RESTRICT ctx )
 {
     return ( ctx != nullptr ) ? ctx->isBeamBeamTrackingEnabled() : false;
 }
 
 
-SIXTRL_HOST_FN void NS(ClContext_enable_beam_beam_tracking)(
+void NS(ClContext_enable_beam_beam_tracking)(
     NS(ClContext)* SIXTRL_RESTRICT ctx )
 {
     if( ctx != nullptr )
@@ -1940,7 +2252,7 @@ SIXTRL_HOST_FN void NS(ClContext_enable_beam_beam_tracking)(
     return;
 }
 
-SIXTRL_HOST_FN void NS(ClContext_disable_beam_beam_tracking)(
+void NS(ClContext_disable_beam_beam_tracking)(
     NS(ClContext)* SIXTRL_RESTRICT ctx )
 {
     if( ctx != nullptr )

--- a/sixtracklib/opencl/internal/context.cpp
+++ b/sixtracklib/opencl/internal/context.cpp
@@ -648,18 +648,16 @@ namespace SIXTRL_CXX_NAMESPACE
     bool ClContext::hasLineTrackingKernel() const SIXTRL_NOEXCEPT
     {
         return ( ( this->hasSelectedNode() ) &&
-                 ( this->m_track_single_turn_kernel_id >= kernel_id_t{ 0 } ) &&
-                 ( static_cast< size_type >(
-                     this->m_track_single_turn_kernel_id ) <
-                         this->numAvailableKernels() ) );
+            ( this->m_track_line_kernel_id >= kernel_id_t{ 0 } ) &&
+                ( static_cast< size_type >( this->m_track_line_kernel_id ) <
+                    this->numAvailableKernels() ) );
     }
 
     ClContext::kernel_id_t
     ClContext::lineTrackingKernelId() const SIXTRL_NOEXCEPT
     {
         return ( this->hasTrackingKernel() )
-            ? this->m_track_until_turn_kernel_id
-            : ClContext::kernel_id_t{ -1 };
+            ? this->m_track_line_kernel_id : ClContext::kernel_id_t{ -1 };
     }
 
     bool ClContext::setTrackLineKernelId(
@@ -679,8 +677,8 @@ namespace SIXTRL_CXX_NAMESPACE
                 ( static_cast< size_type >( program_id ) <
                     this->numAvailablePrograms() ) )
             {
-                this->m_track_single_turn_kernel_id  = kernel_id;
-                this->m_track_single_turn_program_id = program_id;
+                this->m_track_line_kernel_id  = kernel_id;
+                this->m_track_line_program_id = program_id;
                 success = true;
             }
         }
@@ -693,7 +691,7 @@ namespace SIXTRL_CXX_NAMESPACE
         ClContext::size_type const line_end_idx, bool const finish_turn )
     {
         return this->trackLine( line_begin_idx, line_end_idx,
-            finish_turn, this->m_track_single_turn_kernel_id );
+            finish_turn, this->m_track_line_kernel_id );
     }
 
     int ClContext::trackLine(
@@ -731,7 +729,7 @@ namespace SIXTRL_CXX_NAMESPACE
     {
         return this->trackLine( particles_arg, particle_set_index,
             beam_elements_arg, line_begin_idx, line_end_idx, finish_turn,
-                this->m_track_single_turn_kernel_id );
+                this->m_track_line_kernel_id );
     }
 
     int ClContext::trackLine(

--- a/sixtracklib/opencl/internal/optimized_priv_particle.h
+++ b/sixtracklib/opencl/internal/optimized_priv_particle.h
@@ -1,0 +1,61 @@
+#ifndef SIXTRACKLIB_OPENCL_INTERNAL_OPTIMIZED_PRIVATE_PARTICLE_H__
+#define SIXTRACKLIB_OPENCL_INTERNAL_OPTIMIZED_PRIVATE_PARTICLE_H__
+
+#if !defined( SIXTRL_NO_INCLUDES )
+    #include "sixtracklib/common/definitions.h"
+    #include "sixtracklib/common/internal/particles_defines.h"
+    #include "sixtracklib/common/particles.h"
+#endif /* !defined( SIXTRL_NO_INCLUDES ) */
+
+#if defined( __OPENCL_VERSION__ )
+
+    SIXTRL_STATIC SIXTRL_DEVICE_FN
+    void NS(OpenCl1x_init_optimized_priv_particle)(
+        SIXTRL_PARTICLE_ARGPTR_DEC NS(Particles)* SIXTRL_RESTRICT part,
+        NS(particle_real_t)* SIXTRL_RESTRICT real_values,
+        NS(particle_index_t)* SIXTRL_RESTRICT index_values );
+
+    /* --------------------------------------------------------------------- */
+
+    SIXTRL_INLINE void NS(OpenCl1x_init_optimized_priv_particle)(
+        SIXTRL_PARTICLE_ARGPTR_DEC NS(Particles)* SIXTRL_RESTRICT part,
+        NS(particle_real_t)* SIXTRL_RESTRICT real_values,
+        NS(particle_index_t)* SIXTRL_RESTRICT index_values )
+    {
+        SIXTRL_ASSERT( part != SIXTRL_NULLPTR );
+        SIXTRL_ASSERT( real_values  != SIXTRL_NULLPTR );
+        SIXTRL_ASSERT( index_values != SIXTRL_NULLPTR );
+
+        NS(Particles_set_num_of_particles)(        part, 1u );
+        NS(Particles_assign_ptr_to_q0)(            part, &real_values[  0 ] );
+        NS(Particles_assign_ptr_to_mass0)(         part, &real_values[  1 ] );
+        NS(Particles_assign_ptr_to_beta0)(         part, &real_values[  2 ] );
+        NS(Particles_assign_ptr_to_gamma0)(        part, &real_values[  3 ] );
+        NS(Particles_assign_ptr_to_p0c)(           part, &real_values[  4 ] );
+
+        NS(Particles_assign_ptr_to_s)(             part, &real_values[  5 ] );
+        NS(Particles_assign_ptr_to_x)(             part, &real_values[  6 ] );
+        NS(Particles_assign_ptr_to_y)(             part, &real_values[  7 ] );
+        NS(Particles_assign_ptr_to_px)(            part, &real_values[  8 ] );
+        NS(Particles_assign_ptr_to_py)(            part, &real_values[  9 ] );
+        NS(Particles_assign_ptr_to_zeta)(          part, &real_values[ 10 ] );
+
+        NS(Particles_assign_ptr_to_psigma)(        part, &real_values[ 11 ] );
+        NS(Particles_assign_ptr_to_delta)(         part, &real_values[ 12 ] );
+        NS(Particles_assign_ptr_to_rpp)(           part, &real_values[ 13 ] );
+        NS(Particles_assign_ptr_to_rvv)(           part, &real_values[ 14 ] );
+        NS(Particles_assign_ptr_to_chi)(           part, &real_values[ 15 ] );
+        NS(Particles_assign_ptr_to_charge_ratio)(  part, &real_values[ 16 ] );
+
+        NS(Particles_assign_ptr_to_particle_id)(   part, &index_values[ 0 ] );
+        NS(Particles_assign_ptr_to_at_element_id)( part, &index_values[ 1 ] );
+        NS(Particles_assign_ptr_to_at_turn)(       part, &index_values[ 2 ] );
+        NS(Particles_assign_ptr_to_state)(         part, &index_values[ 3 ] );
+
+        return;
+    }
+
+#endif /* defined( __OPENCL_VERSION__ ) */
+
+#endif /* SIXTRACKLIB_OPENCL_INTERNAL_OPTIMIZED_PRIVATE_PARTICLE_H__ */
+/* end: sixtracklib/opencl/internal/optimized_priv_particle.h */

--- a/sixtracklib/opencl/internal/success_flag.h
+++ b/sixtracklib/opencl/internal/success_flag.h
@@ -1,0 +1,48 @@
+#ifndef SIXTRACKLIB_OPENCL_INTERNAL_SUCCESS_FLAG_H__
+#define SIXTRACKLIB_OPENCL_INTERNAL_SUCCESS_FLAG_H__
+
+#if !defined( SIXTRL_NO_INCLUDES )
+    #include "sixtracklib/common/definitions.h"
+#endif /* !defined( SIXTRL_NO_INCLUDES ) */
+
+typedef SIXTRL_INT32_T NS(opencl_success_flag_t);
+
+#if defined( __OPENCL_VERSION__ )
+    #if __OPENCL_VERSION__ == CL_VERSION_1_0 && \
+        defined( cl_khr_int32_extended_atomics )
+        #pragma OPENCL EXTENSION cl_khr_int32_extended_atomics : enable
+    #endif /* OpenCL 1.x cl_khr_int32_extended_atomics available */
+
+    SIXTRL_STATIC SIXTRL_DEVICE_FN
+    void NS(OpenCl1x_collect_success_flag_value)( SIXTRL_BUFFER_DATAPTR_DEC
+        NS(opencl_success_flag_t)* SIXTRL_RESTRICT ptr_success_flag,
+        NS(opencl_success_flag_t) const local_success_flag );
+
+    /* --------------------------------------------------------------------- */
+
+    SIXTRL_INLINE void NS(OpenCl1x_collect_success_flag_value)(
+        SIXTRL_BUFFER_DATAPTR_DEC NS(opencl_success_flag_t)*
+            SIXTRL_RESTRICT ptr_success_flag,
+        NS(opencl_success_flag_t) const local_success_flag )
+    {
+        if( ( ptr_success_flag != SIXTRL_NULLPTR ) &&
+            ( local_success_flag > ( NS(opencl_success_flag_t) )0u ) )
+        {
+            #if  __OPENCL_VERSION__ == CL_VERSION_1_0 && \
+                defined( cl_khr_int32_extended_atomics )
+
+                atom_or( ptr_success_flag, local_success_flag );
+
+            #elif __OPENCL_VERSION__ > CL_VERSION_1_0
+                /* Above OpenCL 1.0, atomic_or should always be available */
+                atomic_or( ptr_success_flag, local_success_flag );
+
+            #endif /* !defined( cl_khr_int32_extended_atomics ) */
+        }
+
+        return;
+    }
+#endif /* defined( __OPENCL_VERSION__ ) */
+
+#endif /* SIXTRACKLIB_OPENCL_INTERNAL_SUCCESS_FLAG_H__ */
+/* end: sixtracklib/opencl/internal/success_flag.h */

--- a/sixtracklib/opencl/internal/track_job_cl.cpp
+++ b/sixtracklib/opencl/internal/track_job_cl.cpp
@@ -508,9 +508,6 @@ namespace SIXTRL_CXX_NAMESPACE
             SIXTRL_ASSERT( this->particleSetIndicesBegin() != nullptr );
             SIXTRL_ASSERT( this->numParticleSets() == size_t{ 1 } );
 
-            size_t const particle_set_index =
-                *( this->particleSetIndicesBegin() );
-
             size_t const total_num_particles =
             ::NS(Particles_buffer_get_total_num_of_particles_on_particle_sets)(
                 pb, this->numParticleSets(), this->particleSetIndicesBegin() );
@@ -527,7 +524,9 @@ namespace SIXTRL_CXX_NAMESPACE
                 ( this->particlesArg().ptrCObjectBuffer() == pb ) &&
                 ( ( !this->context().hasSelectedNode() ) ||
                   (  this->context().assignParticleArg(
-                        this->particlesArg(), particle_set_index ) ) ) )
+                        this->particlesArg(),
+                        this->particleSetIndicesBegin(),
+                        this->particleSetIndicesEnd() ) ) ) )
             {
                 success = true;
             }
@@ -815,10 +814,6 @@ namespace SIXTRL_CXX_NAMESPACE
         SIXTRL_ASSERT( job.ptrContext() != nullptr );
         SIXTRL_ASSERT( job.ptrParticlesArg() != nullptr );
         SIXTRL_ASSERT( job.ptrBeamElementsArg() != nullptr );
-        SIXTRL_ASSERT( job.hasOutputBuffer() );
-        SIXTRL_ASSERT( job.ptrOutputBufferArg() != nullptr );
-        SIXTRL_ASSERT( job.hasElemByElemOutput() );
-        SIXTRL_ASSERT( job.ptrElemByElemConfig() != nullptr );
         SIXTRL_ASSERT( job.totalNumParticles() > TrackJobCl::size_type{ 0 } );
 
         ClContext& ctx = job.context();

--- a/sixtracklib/opencl/internal/track_job_cl.cpp
+++ b/sixtracklib/opencl/internal/track_job_cl.cpp
@@ -22,7 +22,7 @@
 
 namespace SIXTRL_CXX_NAMESPACE
 {
-    SIXTRL_HOST_FN TrackJobCl::TrackJobCl(
+    TrackJobCl::TrackJobCl(
         std::string const& SIXTRL_RESTRICT_REF device_id_str,
         std::string const& SIXTRL_RESTRICT_REF config_str ) :
         TrackJobBase( SIXTRL_CXX_NAMESPACE::TRACK_JOB_CL_STR,
@@ -47,7 +47,7 @@ namespace SIXTRL_CXX_NAMESPACE
             device_id_str.c_str(), this->ptrConfigStr() );
     }
 
-    SIXTRL_HOST_FN TrackJobCl::TrackJobCl(
+    TrackJobCl::TrackJobCl(
         const char *const SIXTRL_RESTRICT device_id_str,
         const char *const SIXTRL_RESTRICT config_str ) :
         TrackJobBase( SIXTRL_CXX_NAMESPACE::TRACK_JOB_CL_STR,
@@ -70,7 +70,7 @@ namespace SIXTRL_CXX_NAMESPACE
         this->doPrepareContextOclImpl( device_id_str, this->ptrConfigStr() );
     }
 
-    SIXTRL_HOST_FN TrackJobCl::TrackJobCl(
+    TrackJobCl::TrackJobCl(
         const char *const SIXTRL_RESTRICT device_id_str,
         TrackJobCl::c_buffer_t* SIXTRL_RESTRICT particles_buffer,
         TrackJobCl::c_buffer_t* SIXTRL_RESTRICT beam_elements_buffer,
@@ -92,7 +92,7 @@ namespace SIXTRL_CXX_NAMESPACE
             config_str );
     }
 
-    SIXTRL_HOST_FN TrackJobCl::TrackJobCl(
+    TrackJobCl::TrackJobCl(
         const char *const SIXTRL_RESTRICT device_id_str,
         TrackJobCl::c_buffer_t* SIXTRL_RESTRICT particles_buffer,
         TrackJobCl::size_type const num_particle_sets,
@@ -123,7 +123,7 @@ namespace SIXTRL_CXX_NAMESPACE
             until_turn_elem_by_elem, config_str );
     }
 
-    SIXTRL_HOST_FN TrackJobCl::TrackJobCl(
+    TrackJobCl::TrackJobCl(
         std::string const& SIXTRL_RESTRICT_REF device_id_str,
         TrackJobCl::buffer_t& SIXTRL_RESTRICT_REF particles_buffer,
         TrackJobCl::buffer_t& SIXTRL_RESTRICT_REF belements_buffer,
@@ -164,9 +164,9 @@ namespace SIXTRL_CXX_NAMESPACE
         }
     }
 
-    SIXTRL_HOST_FN TrackJobCl::~TrackJobCl() SIXTRL_NOEXCEPT {}
+    TrackJobCl::~TrackJobCl() SIXTRL_NOEXCEPT {}
 
-    SIXTRL_HOST_FN TrackJobCl::cl_context_t&
+    TrackJobCl::cl_context_t&
     TrackJobCl::context() SIXTRL_RESTRICT
     {
         return const_cast< TrackJobCl::cl_context_t& >(
@@ -174,114 +174,114 @@ namespace SIXTRL_CXX_NAMESPACE
     }
 
 
-    SIXTRL_HOST_FN TrackJobCl::cl_context_t const&
+    TrackJobCl::cl_context_t const&
     TrackJobCl::context() const SIXTRL_RESTRICT
     {
         SIXTRL_ASSERT( this->ptrContext() != nullptr );
         return *( this->ptrContext() );
     }
 
-    SIXTRL_HOST_FN ::NS(ClContext)* TrackJobCl::ptrContext() SIXTRL_RESTRICT
+    ::NS(ClContext)* TrackJobCl::ptrContext() SIXTRL_RESTRICT
     {
         return this->m_ptr_context.get();
     }
 
-    SIXTRL_HOST_FN ::NS(ClContext) const*
+    ::NS(ClContext) const*
     TrackJobCl::ptrContext() const SIXTRL_RESTRICT
     {
         return this->m_ptr_context.get();
     }
 
-    SIXTRL_HOST_FN TrackJobCl::cl_arg_t&
+    TrackJobCl::cl_arg_t&
     TrackJobCl::particlesArg() SIXTRL_NOEXCEPT
     {
         return const_cast< TrackJobCl::cl_arg_t& >(
             static_cast< TrackJobCl const& >( *this ).particlesArg() );
     }
 
-    SIXTRL_HOST_FN TrackJobCl::cl_arg_t const&
+    TrackJobCl::cl_arg_t const&
     TrackJobCl::particlesArg() const SIXTRL_NOEXCEPT
     {
         SIXTRL_ASSERT( this->ptrParticlesArg() != nullptr );
         return *(this->ptrParticlesArg() );
     }
 
-    SIXTRL_HOST_FN TrackJobCl::cl_arg_t*
+    TrackJobCl::cl_arg_t*
     TrackJobCl::ptrParticlesArg() SIXTRL_NOEXCEPT
     {
         return const_cast< TrackJobCl::cl_arg_t* >( static_cast<
             TrackJobCl const& >( *this ).ptrParticlesArg() );
     }
 
-    SIXTRL_HOST_FN TrackJobCl::cl_arg_t const*
+    TrackJobCl::cl_arg_t const*
     TrackJobCl::ptrParticlesArg() const SIXTRL_NOEXCEPT
     {
         return this->m_ptr_particles_buffer_arg.get();
     }
 
-    SIXTRL_HOST_FN TrackJobCl::cl_arg_t&
+    TrackJobCl::cl_arg_t&
     TrackJobCl::beamElementsArg() SIXTRL_NOEXCEPT
     {
         return const_cast< TrackJobCl::cl_arg_t& >( static_cast<
             TrackJobCl const& >( *this ).beamElementsArg() );
     }
 
-    SIXTRL_HOST_FN TrackJobCl::cl_arg_t const&
+    TrackJobCl::cl_arg_t const&
     TrackJobCl::beamElementsArg() const SIXTRL_NOEXCEPT
     {
         SIXTRL_ASSERT( this->ptrBeamElementsArg() != nullptr );
         return *( this->ptrBeamElementsArg() );
     }
 
-    SIXTRL_HOST_FN TrackJobCl::cl_arg_t*
+    TrackJobCl::cl_arg_t*
     TrackJobCl::ptrBeamElementsArg() SIXTRL_NOEXCEPT
     {
         return const_cast< TrackJobCl::cl_arg_t* >( static_cast<
             TrackJobCl const& >( *this ).ptrBeamElementsArg() );
     }
 
-    SIXTRL_HOST_FN TrackJobCl::cl_arg_t const*
+    TrackJobCl::cl_arg_t const*
     TrackJobCl::ptrBeamElementsArg() const SIXTRL_NOEXCEPT
     {
         return this->m_ptr_beam_elements_buffer_arg.get();
     }
 
-    SIXTRL_HOST_FN TrackJobCl::cl_arg_t&
+    TrackJobCl::cl_arg_t&
     TrackJobCl::outputBufferArg() SIXTRL_NOEXCEPT
     {
         return const_cast< TrackJobCl::cl_arg_t& >( static_cast<
             TrackJobCl const& >( *this ).outputBufferArg() );
     }
 
-    SIXTRL_HOST_FN TrackJobCl::cl_arg_t const&
+    TrackJobCl::cl_arg_t const&
     TrackJobCl::outputBufferArg() const SIXTRL_NOEXCEPT
     {
         SIXTRL_ASSERT( this->ptrOutputBufferArg() != nullptr );
         return *( this->m_ptr_output_buffer_arg );
     }
 
-    SIXTRL_HOST_FN TrackJobCl::cl_arg_t*
+    TrackJobCl::cl_arg_t*
     TrackJobCl::ptrOutputBufferArg() SIXTRL_NOEXCEPT
     {
         return const_cast< TrackJobCl::cl_arg_t* >( static_cast<
             TrackJobCl const& >( *this ).ptrOutputBufferArg() );
     }
 
-    SIXTRL_HOST_FN TrackJobCl::cl_arg_t const*
+    TrackJobCl::cl_arg_t const*
     TrackJobCl::ptrOutputBufferArg() const SIXTRL_NOEXCEPT
     {
         return this->m_ptr_output_buffer_arg.get();
     }
 
 
-    SIXTRL_HOST_FN TrackJobCl::cl_buffer_t const&
+    TrackJobCl::cl_buffer_t const&
     TrackJobCl::clElemByElemConfigBuffer() const SIXTRL_NOEXCEPT
     {
         SIXTRL_ASSERT( this->ptrClElemByElemConfigBuffer() != nullptr );
         return *( this->ptrClElemByElemConfigBuffer() );
     }
 
-    SIXTRL_HOST_FN TrackJobCl::cl_buffer_t&
+    TrackJobCl::cl_buffer_t&
     TrackJobCl::clElemByElemConfigBuffer() SIXTRL_NOEXCEPT
     {
         using _this_t = TrackJobCl;
@@ -291,34 +291,34 @@ namespace SIXTRL_CXX_NAMESPACE
                 *this ).clElemByElemConfigBuffer() );
     }
 
-    SIXTRL_HOST_FN TrackJobCl::cl_buffer_t const*
+    TrackJobCl::cl_buffer_t const*
     TrackJobCl::ptrClElemByElemConfigBuffer() const SIXTRL_NOEXCEPT
     {
         return this->m_ptr_cl_elem_by_elem_config_buffer.get();
     }
 
-    SIXTRL_HOST_FN TrackJobCl::cl_buffer_t*
+    TrackJobCl::cl_buffer_t*
     TrackJobCl::ptrClElemByElemConfigBuffer() SIXTRL_NOEXCEPT
     {
         return this->m_ptr_cl_elem_by_elem_config_buffer.get();
     }
 
 
-    SIXTRL_HOST_FN bool TrackJobCl::doPrepareParticlesStructures(
+    bool TrackJobCl::doPrepareParticlesStructures(
         TrackJobCl::c_buffer_t* SIXTRL_RESTRICT pb )
     {
         return ( ( TrackJobBase::doPrepareParticlesStructures( pb ) ) &&
                  ( this->doPrepareParticlesStructuresOclImp( pb ) ) );
     }
 
-    SIXTRL_HOST_FN bool TrackJobCl::doPrepareBeamElementsStructures(
+    bool TrackJobCl::doPrepareBeamElementsStructures(
         TrackJobCl::c_buffer_t* SIXTRL_RESTRICT belems )
     {
         return ( ( TrackJobBase::doPrepareBeamElementsStructures( belems ) ) &&
             ( this->doPrepareBeamElementsStructuresOclImp( belems ) ) );
     }
 
-    SIXTRL_HOST_FN bool TrackJobCl::doPrepareOutputStructures(
+    bool TrackJobCl::doPrepareOutputStructures(
         TrackJobCl::c_buffer_t* SIXTRL_RESTRICT part_buffer,
         TrackJobCl::c_buffer_t* SIXTRL_RESTRICT belem_buffer,
         TrackJobCl::c_buffer_t* SIXTRL_RESTRICT output_buffer,
@@ -337,7 +337,7 @@ namespace SIXTRL_CXX_NAMESPACE
         return success;
     }
 
-    SIXTRL_HOST_FN bool TrackJobCl::doAssignOutputBufferToBeamMonitors(
+    bool TrackJobCl::doAssignOutputBufferToBeamMonitors(
         TrackJobCl::c_buffer_t* SIXTRL_RESTRICT belem_buffer,
         TrackJobCl::c_buffer_t* SIXTRL_RESTRICT out_buffer )
     {
@@ -355,7 +355,7 @@ namespace SIXTRL_CXX_NAMESPACE
         return success;
     }
 
-    SIXTRL_HOST_FN bool TrackJobCl::doReset(
+    bool TrackJobCl::doReset(
         TrackJobCl::c_buffer_t* SIXTRL_RESTRICT particles_buffer,
         TrackJobCl::c_buffer_t* SIXTRL_RESTRICT beam_elem_buffer,
         TrackJobCl::c_buffer_t* SIXTRL_RESTRICT ptr_output_buffer,
@@ -365,13 +365,13 @@ namespace SIXTRL_CXX_NAMESPACE
                 ptr_output_buffer, until_turn_elem_by_elem );
     }
 
-    SIXTRL_HOST_FN TrackJobCl::track_status_t TrackJobCl::doTrackUntilTurn(
+    TrackJobCl::track_status_t TrackJobCl::doTrackUntilTurn(
         TrackJobCl::size_type const until_turn )
     {
         return SIXTRL_CXX_NAMESPACE::track( *this, until_turn );
     }
 
-    SIXTRL_HOST_FN TrackJobCl::track_status_t TrackJobCl::doTrackElemByElem(
+    TrackJobCl::track_status_t TrackJobCl::doTrackElemByElem(
         TrackJobCl::size_type const until_turn )
     {
         return SIXTRL_CXX_NAMESPACE::trackElemByElem( *this, until_turn );
@@ -387,47 +387,45 @@ namespace SIXTRL_CXX_NAMESPACE
     }
 
 
-    SIXTRL_HOST_FN void TrackJobCl::doCollect()
+    void TrackJobCl::doCollect( TrackJobCl::collect_flag_t const flags )
     {
-        SIXTRL_CXX_NAMESPACE::collect( *this );
-        return;
+        SIXTRL_CXX_NAMESPACE::collect( *this, flags );
     }
 
-    SIXTRL_HOST_FN void TrackJobCl::doParseConfigStr(
-        const char *const SIXTRL_RESTRICT  )
+    void TrackJobCl::doParseConfigStr( const char *const SIXTRL_RESTRICT  )
     {
         return;
     }
 
-    SIXTRL_HOST_FN void TrackJobCl::doUpdateStoredContext(
+    void TrackJobCl::doUpdateStoredContext(
         TrackJobCl::ptr_cl_context_t&& context )
     {
         this->m_ptr_context = std::move( context );
         return;
     }
 
-    SIXTRL_HOST_FN void TrackJobCl::doUpdateStoredParticlesArg(
+    void TrackJobCl::doUpdateStoredParticlesArg(
         TrackJobCl::ptr_cl_arg_t&& particle_arg )
     {
         this->m_ptr_particles_buffer_arg = std::move( particle_arg );
         return;
     }
 
-    SIXTRL_HOST_FN void TrackJobCl::doUpdateStoredBeamElementsArg(
+    void TrackJobCl::doUpdateStoredBeamElementsArg(
         TrackJobCl::ptr_cl_arg_t&& beam_elements_arg )
     {
         this->m_ptr_beam_elements_buffer_arg = std::move( beam_elements_arg );
         return;
     }
 
-    SIXTRL_HOST_FN void TrackJobCl::doUpdateStoredOutputArg(
+    void TrackJobCl::doUpdateStoredOutputArg(
         TrackJobCl::ptr_cl_arg_t&& output_arg )
     {
         this->m_ptr_output_buffer_arg = std::move( output_arg );
         return;
     }
 
-    SIXTRL_HOST_FN void TrackJobCl::doUpdateStoredClElemByElemConfigBuffer(
+    void TrackJobCl::doUpdateStoredClElemByElemConfigBuffer(
             TrackJobCl::ptr_cl_buffer_t&& cl_elem_by_elem_config_buffer )
     {
         this->m_ptr_cl_elem_by_elem_config_buffer =
@@ -436,27 +434,26 @@ namespace SIXTRL_CXX_NAMESPACE
         return;
     }
 
-    SIXTRL_HOST_FN TrackJobCl::size_type
-    TrackJobCl::totalNumParticles() const SIXTRL_NOEXCEPT
+    TrackJobCl::size_type TrackJobCl::totalNumParticles() const SIXTRL_NOEXCEPT
     {
         return this->m_total_num_particles;
     }
 
-    SIXTRL_HOST_FN void TrackJobCl::doSetTotalNumParticles(
+    void TrackJobCl::doSetTotalNumParticles(
         TrackJobCl::size_type const total_num_particles ) SIXTRL_NOEXCEPT
     {
         this->m_total_num_particles = total_num_particles;
         return;
     }
 
-    SIXTRL_HOST_FN bool TrackJobCl::doPrepareContext(
+    bool TrackJobCl::doPrepareContext(
         char const* SIXTRL_RESTRICT device_id_str,
         char const* SIXTRL_RESTRICT ptr_config_str )
     {
         return this->doPrepareContextOclImpl( device_id_str, ptr_config_str );
     }
 
-    SIXTRL_HOST_FN bool TrackJobCl::doPrepareContextOclImpl(
+    bool TrackJobCl::doPrepareContextOclImpl(
         const char *const SIXTRL_RESTRICT device_id_str,
         const char *const SIXTRL_RESTRICT ptr_config_str )
     {
@@ -489,13 +486,13 @@ namespace SIXTRL_CXX_NAMESPACE
         return success;
     }
 
-    SIXTRL_HOST_FN void TrackJobCl::doParseConfigStrOclImpl(
+    void TrackJobCl::doParseConfigStrOclImpl(
         const char *const SIXTRL_RESTRICT )
     {
         return;
     }
 
-    SIXTRL_HOST_FN bool TrackJobCl::doPrepareParticlesStructuresOclImp(
+    bool TrackJobCl::doPrepareParticlesStructuresOclImp(
         TrackJobCl::c_buffer_t* SIXTRL_RESTRICT pb )
     {
         using _this_t = TrackJobCl;
@@ -508,6 +505,12 @@ namespace SIXTRL_CXX_NAMESPACE
 
         if( ( this->ptrContext() != nullptr ) && ( pb != nullptr ) )
         {
+            SIXTRL_ASSERT( this->particleSetIndicesBegin() != nullptr );
+            SIXTRL_ASSERT( this->numParticleSets() == size_t{ 1 } );
+
+            size_t const particle_set_index =
+                *( this->particleSetIndicesBegin() );
+
             size_t const total_num_particles =
             ::NS(Particles_buffer_get_total_num_of_particles_on_particle_sets)(
                 pb, this->numParticleSets(), this->particleSetIndicesBegin() );
@@ -524,7 +527,7 @@ namespace SIXTRL_CXX_NAMESPACE
                 ( this->particlesArg().ptrCObjectBuffer() == pb ) &&
                 ( ( !this->context().hasSelectedNode() ) ||
                   (  this->context().assignParticleArg(
-                        this->particlesArg() ) ) ) )
+                        this->particlesArg(), particle_set_index ) ) ) )
             {
                 success = true;
             }
@@ -533,7 +536,7 @@ namespace SIXTRL_CXX_NAMESPACE
         return success;
     }
 
-    SIXTRL_HOST_FN bool TrackJobCl::doPrepareBeamElementsStructuresOclImp(
+    bool TrackJobCl::doPrepareBeamElementsStructuresOclImp(
         TrackJobCl::c_buffer_t* SIXTRL_RESTRICT belems )
     {
         using _this_t = TrackJobCl;
@@ -561,7 +564,7 @@ namespace SIXTRL_CXX_NAMESPACE
         return success;
     }
 
-    SIXTRL_HOST_FN bool TrackJobCl::doPrepareOutputStructuresOclImpl(
+    bool TrackJobCl::doPrepareOutputStructuresOclImpl(
         TrackJobCl::c_buffer_t* SIXTRL_RESTRICT pb,
         TrackJobCl::c_buffer_t* SIXTRL_RESTRICT belems,
         TrackJobCl::c_buffer_t* SIXTRL_RESTRICT ptr_out_buffer,
@@ -631,7 +634,7 @@ namespace SIXTRL_CXX_NAMESPACE
         return success;
     }
 
-    SIXTRL_HOST_FN bool TrackJobCl::doAssignOutputBufferToBeamMonitorsOclImp(
+    bool TrackJobCl::doAssignOutputBufferToBeamMonitorsOclImp(
         TrackJobCl::c_buffer_t* SIXTRL_RESTRICT belem_buffer,
         TrackJobCl::c_buffer_t* SIXTRL_RESTRICT output_buffer )
     {
@@ -661,7 +664,7 @@ namespace SIXTRL_CXX_NAMESPACE
         return false;
     }
 
-    SIXTRL_HOST_FN bool TrackJobCl::doResetOclImp(
+    bool TrackJobCl::doResetOclImp(
         TrackJobCl::c_buffer_t* SIXTRL_RESTRICT pb,
         TrackJobCl::c_buffer_t* SIXTRL_RESTRICT belem_buffer,
         TrackJobCl::c_buffer_t* SIXTRL_RESTRICT out_buffer,
@@ -712,22 +715,36 @@ namespace SIXTRL_CXX_NAMESPACE
         return success;
     }
 
-    SIXTRL_HOST_FN void collect(
+    void collect(
         TrackJobCl& SIXTRL_RESTRICT_REF job ) SIXTRL_NOEXCEPT
     {
-        if( ( job.ptrParticlesArg()       != nullptr ) &&
-            ( job.ptrCParticlesBuffer()   != nullptr ) )
+        SIXTRL_CXX_NAMESPACE::collect( job, job.collectFlags() );
+        return;
+    }
+
+    void collect( TrackJobCl& SIXTRL_RESTRICT_REF job,
+            SIXTRL_CXX_NAMESPACE::track_job_collect_flag_t const flags
+        ) SIXTRL_NOEXCEPT
+    {
+        if( ( TrackJobCl::IsCollectFlagSet(
+                flags, TRACK_JOB_COLLECT_PARTICLES ) ) &&
+            ( job.ptrParticlesArg() != nullptr ) &&
+            ( job.ptrCParticlesBuffer() != nullptr ) )
         {
             job.particlesArg().read( job.ptrCParticlesBuffer() );
         }
 
-        if( ( job.ptrOutputBufferArg() != nullptr ) &&
-            ( job.ptrCOutputBuffer()   != nullptr ) )
+        if( ( TrackJobCl::IsCollectFlagSet(
+                flags, TRACK_JOB_COLLECT_OUTPUT ) ) &&
+            ( job.ptrOutputBufferArg() != nullptr ) &&
+            ( job.ptrCOutputBuffer() != nullptr ) )
         {
             job.outputBufferArg().read( job.ptrCOutputBuffer() );
         }
 
-        if( ( job.ptrBeamElementsArg() != nullptr ) &&
+        if( ( TrackJobCl::IsCollectFlagSet(
+                flags, TRACK_JOB_COLLECT_BEAM_ELEMENTS ) ) &&
+            ( job.ptrBeamElementsArg() != nullptr ) &&
             ( job.ptrCBeamElementsBuffer() != nullptr ) )
         {
             job.beamElementsArg().read( job.ptrCBeamElementsBuffer() );
@@ -736,7 +753,7 @@ namespace SIXTRL_CXX_NAMESPACE
         return;
     }
 
-    SIXTRL_HOST_FN TrackJobCl::track_status_t track(
+    TrackJobCl::track_status_t track(
         TrackJobCl& SIXTRL_RESTRICT_REF job,
         TrackJobCl::size_type const until_turn ) SIXTRL_NOEXCEPT
     {
@@ -759,7 +776,7 @@ namespace SIXTRL_CXX_NAMESPACE
             ? status_t{ 0 } : status_t{ -1 };
     }
 
-    SIXTRL_HOST_FN TrackJobCl::track_status_t trackElemByElem(
+    TrackJobCl::track_status_t trackElemByElem(
         TrackJobCl& SIXTRL_RESTRICT_REF job,
         TrackJobCl::size_type const until_turn ) SIXTRL_NOEXCEPT
     {
@@ -789,7 +806,7 @@ namespace SIXTRL_CXX_NAMESPACE
             ? status_t{ 0 } : status_t{ -1 };
     }
 
-    SIXTRL_HOST_FN TrackJobCl::track_status_t trackLine(
+    TrackJobCl::track_status_t trackLine(
         TrackJobCl& SIXTRL_RESTRICT_REF job,
         TrackJobCl::size_type const line_begin_idx,
         TrackJobCl::size_type const line_end_idx,
@@ -812,13 +829,13 @@ namespace SIXTRL_CXX_NAMESPACE
     }
 }
 
-SIXTRL_HOST_FN NS(TrackJobCl)* NS(TrackJobCl_create)(
+NS(TrackJobCl)* NS(TrackJobCl_create)(
     const char *const SIXTRL_RESTRICT device_id_str )
 {
     return new SIXTRL_CXX_NAMESPACE::TrackJobCl( device_id_str, nullptr );
 }
 
-SIXTRL_HOST_FN NS(TrackJobCl)*
+NS(TrackJobCl)*
 NS(TrackJobCl_create_from_config_str)(
     const char *const SIXTRL_RESTRICT device_id_str,
     const char *const SIXTRL_RESTRICT config_str )
@@ -826,7 +843,7 @@ NS(TrackJobCl_create_from_config_str)(
     return new SIXTRL_CXX_NAMESPACE::TrackJobCl( device_id_str, config_str );
 }
 
-SIXTRL_HOST_FN NS(TrackJobCl)* NS(TrackJobCl_new)(
+NS(TrackJobCl)* NS(TrackJobCl_new)(
     const char *const SIXTRL_RESTRICT device_id_str,
     NS(Buffer)* SIXTRL_RESTRICT particles_buffer,
     NS(Buffer)* SIXTRL_RESTRICT beam_elements_buffer )
@@ -835,23 +852,21 @@ SIXTRL_HOST_FN NS(TrackJobCl)* NS(TrackJobCl_new)(
         particles_buffer, beam_elements_buffer );
 }
 
-SIXTRL_HOST_FN NS(TrackJobCl)* NS(TrackJobCl_new_with_output)(
+NS(TrackJobCl)* NS(TrackJobCl_new_with_output)(
     const char *const SIXTRL_RESTRICT device_id_str,
     NS(Buffer)* SIXTRL_RESTRICT particles_buffer,
     NS(Buffer)* SIXTRL_RESTRICT beam_elements_buffer,
     NS(Buffer)* SIXTRL_RESTRICT output_buffer,
     NS(buffer_size_t) const until_turn_elem_by_elem )
 {
-    using size_t = SIXTRL_CXX_NAMESPACE::TrackJobCl::size_type;
-
-    size_t const particle_set_indices[] = { size_t{ 0 }, size_t{ 0 } };
-
-    return new SIXTRL_CXX_NAMESPACE::TrackJobCl( device_id_str,
-        particles_buffer, size_t{ 1 }, &particle_set_indices[ 0 ],
+    using _this_t = SIXTRL_CXX_NAMESPACE::TrackJobCl;
+    return new _this_t( device_id_str, particles_buffer,
+        _this_t::DefaultNumParticleSetIndices(),
+        _this_t::DefaultParticleSetIndicesBegin(),
         beam_elements_buffer, output_buffer, until_turn_elem_by_elem );
 }
 
-SIXTRL_HOST_FN NS(TrackJobCl)* NS(TrackJobCl_new_detailed)(
+NS(TrackJobCl)* NS(TrackJobCl_new_detailed)(
     const char *const SIXTRL_RESTRICT device_id_str,
     NS(Buffer)* SIXTRL_RESTRICT particles_buffer,
     NS(buffer_size_t) const num_particle_sets,
@@ -867,7 +882,7 @@ SIXTRL_HOST_FN NS(TrackJobCl)* NS(TrackJobCl_new_detailed)(
         config_str );
 }
 
-SIXTRL_EXTERN SIXTRL_HOST_FN bool NS(TrackJobCl_reset)(
+SIXTRL_EXTERN bool NS(TrackJobCl_reset)(
     NS(TrackJobCl)* SIXTRL_RESTRICT job,
     NS(Buffer)* SIXTRL_RESTRICT particles_buffer,
     NS(Buffer)* SIXTRL_RESTRICT beam_elements_buffer,
@@ -885,7 +900,7 @@ SIXTRL_EXTERN SIXTRL_HOST_FN bool NS(TrackJobCl_reset)(
     return false;
 }
 
-SIXTRL_EXTERN SIXTRL_HOST_FN bool NS(TrackJobCl_reset_with_output)(
+SIXTRL_EXTERN bool NS(TrackJobCl_reset_with_output)(
     NS(TrackJobCl)* SIXTRL_RESTRICT job,
     NS(Buffer)* SIXTRL_RESTRICT particles_buffer,
     NS(Buffer)* SIXTRL_RESTRICT beam_elements_buffer,
@@ -898,7 +913,7 @@ SIXTRL_EXTERN SIXTRL_HOST_FN bool NS(TrackJobCl_reset_with_output)(
         : false;
 }
 
-SIXTRL_EXTERN SIXTRL_HOST_FN bool NS(TrackJobCl_reset_detailed)(
+SIXTRL_EXTERN bool NS(TrackJobCl_reset_detailed)(
     NS(TrackJobCl)* SIXTRL_RESTRICT job,
     NS(Buffer)* SIXTRL_RESTRICT particles_buffer,
     NS(buffer_size_t) const num_particle_sets,
@@ -914,13 +929,13 @@ SIXTRL_EXTERN SIXTRL_HOST_FN bool NS(TrackJobCl_reset_detailed)(
         : false;
 }
 
-SIXTRL_HOST_FN void NS(TrackJobCl_delete)(
+void NS(TrackJobCl_delete)(
     NS(TrackJobCl)* SIXTRL_RESTRICT track_job )
 {
     delete track_job;
 }
 
-SIXTRL_HOST_FN NS(track_status_t) NS(TrackJobCl_track_until_turn)(
+NS(track_status_t) NS(TrackJobCl_track_until_turn)(
     NS(TrackJobCl)* SIXTRL_RESTRICT track_job,
     NS(buffer_size_t) const until_turn )
 {
@@ -928,7 +943,7 @@ SIXTRL_HOST_FN NS(track_status_t) NS(TrackJobCl_track_until_turn)(
     return SIXTRL_CXX_NAMESPACE::track( *track_job, until_turn );
 }
 
-SIXTRL_HOST_FN NS(track_status_t) NS(TrackJobCl_track_elem_by_elem)(
+NS(track_status_t) NS(TrackJobCl_track_elem_by_elem)(
     NS(TrackJobCl)* SIXTRL_RESTRICT track_job,
     NS(buffer_size_t) const until_turn )
 {
@@ -947,7 +962,7 @@ NS(track_status_t) NS(TrackJobCl_track_line)(
         *track_job, line_begin_idx, line_end_idx, finish_turn );
 }
 
-SIXTRL_HOST_FN void NS(TrackJobCl_collect)(
+void NS(TrackJobCl_collect)(
     NS(TrackJobCl)* SIXTRL_RESTRICT track_job )
 {
     SIXTRL_ASSERT( track_job != nullptr );
@@ -955,59 +970,59 @@ SIXTRL_HOST_FN void NS(TrackJobCl_collect)(
     return;
 }
 
-SIXTRL_HOST_FN NS(ClContext)* NS(TrackJobCl_get_context)(
+NS(ClContext)* NS(TrackJobCl_get_context)(
     NS(TrackJobCl)* SIXTRL_RESTRICT track_job )
 {
     return ( track_job != nullptr ) ? track_job->ptrContext() : nullptr;
 }
 
-SIXTRL_HOST_FN NS(ClContext) const* NS(TrackJobCl_get_const_context)(
+NS(ClContext) const* NS(TrackJobCl_get_const_context)(
     const NS(TrackJobCl) *const SIXTRL_RESTRICT track_job )
 {
     return ( track_job != nullptr ) ? track_job->ptrContext() : nullptr;
 }
 
-SIXTRL_EXTERN SIXTRL_HOST_FN NS(ClArgument)*
+SIXTRL_EXTERN NS(ClArgument)*
 NS(TrackJobCl_get_particles_buffer_arg)(
     NS(TrackJobCl)* SIXTRL_RESTRICT track_job )
 {
     return ( track_job != nullptr ) ? track_job->ptrParticlesArg() : nullptr;
 }
 
-SIXTRL_EXTERN SIXTRL_HOST_FN NS(ClArgument) const*
+SIXTRL_EXTERN NS(ClArgument) const*
 NS(TrackJobCl_get_const_particles_buffer_arg)(
     const NS(TrackJobCl) *const SIXTRL_RESTRICT track_job )
 {
     return ( track_job != nullptr ) ? track_job->ptrParticlesArg() : nullptr;
 }
 
-SIXTRL_EXTERN SIXTRL_HOST_FN NS(ClArgument)*
+SIXTRL_EXTERN NS(ClArgument)*
 NS(TrackJobCl_get_beam_elements_buffer_arg)(
     NS(TrackJobCl)* SIXTRL_RESTRICT job )
 {
     return ( job != nullptr ) ? job->ptrBeamElementsArg() : nullptr;
 }
 
-SIXTRL_EXTERN SIXTRL_HOST_FN NS(ClArgument) const*
+SIXTRL_EXTERN NS(ClArgument) const*
 NS(TrackJobCl_get_const_beam_elements_buffer_arg)(
     const NS(TrackJobCl) *const SIXTRL_RESTRICT job )
 {
     return ( job != nullptr ) ? job->ptrBeamElementsArg() : nullptr;
 }
 
-SIXTRL_EXTERN SIXTRL_HOST_FN bool NS(TrackJobCl_has_output_buffer_arg)(
+SIXTRL_EXTERN bool NS(TrackJobCl_has_output_buffer_arg)(
     const NS(TrackJobCl) *const SIXTRL_RESTRICT job )
 {
     return ( ( job != nullptr ) && ( job->ptrOutputBufferArg() != nullptr ) );
 }
 
-SIXTRL_EXTERN SIXTRL_HOST_FN NS(ClArgument)*
+SIXTRL_EXTERN NS(ClArgument)*
 NS(TrackJobCl_get_output_buffer_arg)( NS(TrackJobCl)* SIXTRL_RESTRICT job )
 {
     return ( job != nullptr ) ? job->ptrOutputBufferArg() : nullptr;
 }
 
-SIXTRL_EXTERN SIXTRL_HOST_FN NS(ClArgument) const*
+SIXTRL_EXTERN NS(ClArgument) const*
 NS(TrackJobCl_get_const_output_buffer_arg)(
     const NS(TrackJobCl) *const SIXTRL_RESTRICT job )
 {

--- a/sixtracklib/opencl/internal/track_job_cl.cpp
+++ b/sixtracklib/opencl/internal/track_job_cl.cpp
@@ -377,6 +377,15 @@ namespace SIXTRL_CXX_NAMESPACE
         return SIXTRL_CXX_NAMESPACE::trackElemByElem( *this, until_turn );
     }
 
+    TrackJobCl::track_status_t TrackJobCl::doTrackLine(
+        TrackJobCl::size_type const line_begin_idx,
+        TrackJobCl::size_type const line_end_idx,
+        bool const finish_turn )
+    {
+        return SIXTRL_CXX_NAMESPACE::trackLine(
+            *this, line_begin_idx, line_end_idx, finish_turn );
+    }
+
 
     SIXTRL_HOST_FN void TrackJobCl::doCollect()
     {
@@ -779,6 +788,28 @@ namespace SIXTRL_CXX_NAMESPACE
         return ( job.context().runKernel( kid, job.totalNumParticles() ) )
             ? status_t{ 0 } : status_t{ -1 };
     }
+
+    SIXTRL_HOST_FN TrackJobCl::track_status_t trackLine(
+        TrackJobCl& SIXTRL_RESTRICT_REF job,
+        TrackJobCl::size_type const line_begin_idx,
+        TrackJobCl::size_type const line_end_idx,
+        bool const finish_turn ) SIXTRL_NOEXCEPT
+    {
+        SIXTRL_ASSERT( job.ptrContext() != nullptr );
+        SIXTRL_ASSERT( job.ptrParticlesArg() != nullptr );
+        SIXTRL_ASSERT( job.ptrBeamElementsArg() != nullptr );
+        SIXTRL_ASSERT( job.hasOutputBuffer() );
+        SIXTRL_ASSERT( job.ptrOutputBufferArg() != nullptr );
+        SIXTRL_ASSERT( job.hasElemByElemOutput() );
+        SIXTRL_ASSERT( job.ptrElemByElemConfig() != nullptr );
+        SIXTRL_ASSERT( job.totalNumParticles() > TrackJobCl::size_type{ 0 } );
+
+        ClContext& ctx = job.context();
+        SIXTRL_ASSERT( ctx.hasSelectedNode() );
+        SIXTRL_ASSERT( ctx.hasLineTrackingKernel() );
+
+        return ctx.trackLine( line_begin_idx, line_end_idx, finish_turn );
+    }
 }
 
 SIXTRL_HOST_FN NS(TrackJobCl)* NS(TrackJobCl_create)(
@@ -903,6 +934,17 @@ SIXTRL_HOST_FN NS(track_status_t) NS(TrackJobCl_track_elem_by_elem)(
 {
     SIXTRL_ASSERT( track_job != nullptr );
     return SIXTRL_CXX_NAMESPACE::trackElemByElem( *track_job, until_turn );
+}
+
+NS(track_status_t) NS(TrackJobCl_track_line)(
+    NS(TrackJobCl)* SIXTRL_RESTRICT track_job,
+    NS(buffer_size_t) const line_begin_idx,
+    NS(buffer_size_t) const line_end_idx,
+    bool const finish_turn )
+{
+    SIXTRL_ASSERT( track_job != nullptr );
+    return SIXTRL_CXX_NAMESPACE::trackLine(
+        *track_job, line_begin_idx, line_end_idx, finish_turn );
 }
 
 SIXTRL_HOST_FN void NS(TrackJobCl_collect)(

--- a/sixtracklib/opencl/kernels/track_particles_optimized_priv_particles.cl
+++ b/sixtracklib/opencl/kernels/track_particles_optimized_priv_particles.cl
@@ -16,7 +16,7 @@
     #include "sixtracklib/common/track.h"
 #endif /* !defined( SIXTRL_NO_INCLUDES ) */
 
-__kernel void NS(Track_particle_line_opt_pp_opencl)(
+__kernel void NS(Track_particles_line_opt_pp_opencl)(
     SIXTRL_BUFFER_DATAPTR_DEC unsigned char* SIXTRL_RESTRICT pbuffer,
     SIXTRL_UINT64_T const particle_set_index,
     SIXTRL_BUFFER_DATAPTR_DEC unsigned char const* SIXTRL_RESTRICT belem_buffer,
@@ -51,7 +51,7 @@ __kernel void NS(Track_particles_elem_by_elem_opt_pp_opencl)(
 
 /* ========================================================================= */
 
-__kernel void NS(Track_particle_line_opt_pp_opencl)(
+__kernel void NS(Track_particles_line_opt_pp_opencl)(
     SIXTRL_BUFFER_DATAPTR_DEC unsigned char* SIXTRL_RESTRICT pbuffer,
     SIXTRL_UINT64_T const particle_set_index,
     SIXTRL_BUFFER_DATAPTR_DEC unsigned char const* SIXTRL_RESTRICT belem_buffer,
@@ -136,7 +136,9 @@ __kernel void NS(Track_particle_line_opt_pp_opencl)(
     SIXTRL_ASSERT( in_particles != SIXTRL_NULLPTR );
     num_particles = in_particles->num_particles;
 
-    NS(OpenCl1x_init_optimized_priv_particle)( &particles, reals, indexes );
+    NS(OpenCl1x_init_optimized_priv_particle)(
+        &particles, &reals[ 0 ], &indexes[ 0 ] );
+
     SIXTRL_ASSERT( particles.num_particles == ( num_element_t )1u );
 
     for( ; particle_id < num_particles ; particle_id += stride )
@@ -205,7 +207,8 @@ __kernel void NS(Track_particles_single_turn_opt_pp_opencl)(
 
     SIXTRL_PARTICLE_ARGPTR_DEC NS(Particles) particles;
 
-    NS(OpenCl1x_init_optimized_priv_particle)( &particles, reals, indexes );
+    NS(OpenCl1x_init_optimized_priv_particle)(
+        &particles, &reals[ 0 ], &indexes[ 0 ] );
 
     SIXTRL_ASSERT( be_begin != SIXTRL_NULLPTR );
     SIXTRL_ASSERT( be_end   != SIXTRL_NULLPTR );
@@ -317,7 +320,8 @@ __kernel void NS(Track_particles_until_turn_opt_pp_opencl)(
     };
 
     SIXTRL_PARTICLE_ARGPTR_DEC NS(Particles) particles;
-    NS(OpenCl1x_init_optimized_priv_particle)( &particles, reals, indexes );
+    NS(OpenCl1x_init_optimized_priv_particle)(
+        &particles, &reals[ 0 ], &indexes[ 0 ] );
 
     SIXTRL_ASSERT( be_begin != SIXTRL_NULLPTR );
     SIXTRL_ASSERT( be_end   != SIXTRL_NULLPTR );
@@ -385,15 +389,17 @@ __kernel void NS(Track_particles_elem_by_elem_opt_pp_opencl)(
     typedef SIXTRL_BUFFER_DATAPTR_DEC NS(ParticlesGenericAddr)*
             ptr_particles_t;
 
-    SIXTRL_STATIC_VAR NS(opencl_success_flag_t) const ZERO_FLAG = ( NS(opencl_success_flag_t) )0u;
+    SIXTRL_STATIC_VAR NS(opencl_success_flag_t) const ZERO_FLAG =
+        ( NS(opencl_success_flag_t) )0u;
 
     num_element_t idx = ( num_element_t )get_global_id( 0 );
     num_element_t num_particles = ( num_element_t )0u;
     num_element_t const stride  = ( num_element_t )get_global_size( 0 );
     buf_size_t const slot_size  = ( buf_size_t )8u;
 
-    obj_const_iter_t be_begin = NS(ManagedBuffer_get_const_objects_index_begin)(
-        belem_buffer, slot_size );
+    obj_const_iter_t be_begin =
+        NS(ManagedBuffer_get_const_objects_index_begin)(
+            belem_buffer, slot_size );
 
     obj_const_iter_t be_end = NS(ManagedBuffer_get_const_objects_index_end)(
         belem_buffer, slot_size );
@@ -423,7 +429,9 @@ __kernel void NS(Track_particles_elem_by_elem_opt_pp_opencl)(
     };
 
     SIXTRL_PARTICLE_ARGPTR_DEC NS(Particles) particles;
-    NS(OpenCl1x_init_optimized_priv_particle)( &particles, reals, indexes );
+
+    NS(OpenCl1x_init_optimized_priv_particle)(
+        &particles, &reals[ 0 ], &indexes[ 0 ] );
 
     SIXTRL_ASSERT( be_begin != SIXTRL_NULLPTR );
     SIXTRL_ASSERT( be_end   != SIXTRL_NULLPTR );
@@ -484,8 +492,9 @@ __kernel void NS(Track_particles_elem_by_elem_opt_pp_opencl)(
         index_t particle_id   = ( index_t )0u;
         index_t turn          = ( index_t )0u;
 
-        NS(opencl_success_flag_t) success = NS(Particles_copy_from_generic_addr_data)(
-            &particles, 0, in_particles, idx );
+        NS(opencl_success_flag_t) success =
+            NS(Particles_copy_from_generic_addr_data)(
+                &particles, 0, in_particles, idx );
 
         start_elem_id = NS(Particles_get_at_element_id_value)( &particles, 0 );
         particle_id = NS(Particles_get_particle_id_value)( &particles, 0 );

--- a/sixtracklib/opencl/kernels/track_particles_optimized_priv_particles.cl
+++ b/sixtracklib/opencl/kernels/track_particles_optimized_priv_particles.cl
@@ -3,15 +3,25 @@
 
 #if !defined( SIXTRL_NO_INCLUDES )
     #include "sixtracklib/opencl/internal/default_compile_options.h"
+    #include "sixtracklib/opencl/internal/success_flag.h"
+    #include "sixtracklib/opencl/internal/optimized_priv_particle.h"
 
     #include "sixtracklib/common/definitions.h"
     #include "sixtracklib/common/buffer/managed_buffer_minimal.h"
     #include "sixtracklib/common/buffer/managed_buffer_remap.h"
+    #include "sixtracklib/common/internal/buffer_object_defines.h"
     #include "sixtracklib/common/internal/particles_defines.h"
     #include "sixtracklib/common/output/elem_by_elem_config.h"
     #include "sixtracklib/common/particles.h"
     #include "sixtracklib/common/track.h"
 #endif /* !defined( SIXTRL_NO_INCLUDES ) */
+
+__kernel void NS(Track_particle_line_opt_pp_opencl)(
+    SIXTRL_BUFFER_DATAPTR_DEC unsigned char* SIXTRL_RESTRICT pbuffer,
+    SIXTRL_UINT64_T const particle_set_index,
+    SIXTRL_BUFFER_DATAPTR_DEC unsigned char const* SIXTRL_RESTRICT belem_buffer,
+    SIXTRL_UINT64_T const line_begin_idx, SIXTRL_UINT64_T const line_end_idx,
+    SIXTRL_UINT64_T const finish_turn_value );
 
 __kernel void NS(Track_particles_single_turn_opt_pp_opencl)(
     SIXTRL_BUFFER_DATAPTR_DEC unsigned char*
@@ -40,6 +50,108 @@ __kernel void NS(Track_particles_elem_by_elem_opt_pp_opencl)(
     SIXTRL_UINT64_T const out_buffer_index_offset );
 
 /* ========================================================================= */
+
+__kernel void NS(Track_particle_line_opt_pp_opencl)(
+    SIXTRL_BUFFER_DATAPTR_DEC unsigned char* SIXTRL_RESTRICT pbuffer,
+    SIXTRL_UINT64_T const particle_set_index,
+    SIXTRL_BUFFER_DATAPTR_DEC unsigned char const* SIXTRL_RESTRICT belem_buffer,
+    SIXTRL_UINT64_T const line_begin_idx, SIXTRL_UINT64_T const line_end_idx,
+    SIXTRL_UINT64_T const finish_turn_value )
+{
+    typedef NS(buffer_size_t)           buf_size_t;
+    typedef NS(particle_num_elements_t) num_element_t;
+    typedef NS(particle_real_t)         real_t;
+    typedef NS(particle_index_t)        index_t;
+
+    typedef SIXTRL_BUFFER_OBJ_ARGPTR_DEC NS(Object) const* be_iter_t;
+    typedef SIXTRL_BUFFER_OBJ_ARGPTR_DEC NS(Object)*       pb_iter_t;
+    typedef SIXTRL_BUFFER_DATAPTR_DEC NS(ParticlesGenericAddr)* ptr_particles_t;
+
+    buf_size_t const slot_size  = ( buf_size_t )8u;
+    num_element_t particle_id   = ( num_element_t )get_global_id( 0 );
+    num_element_t const stride  = ( num_element_t )get_global_size( 0 );
+    num_element_t num_particles = ( num_element_t )0u;
+
+    bool const fin = ( bool )( finish_turn_value > ( SIXTRL_UINT64_T )0u );
+
+    SIXTRL_PARTICLE_ARGPTR_DEC NS(Particles) particles;
+
+    real_t reals[] =
+    {
+        ( real_t )0.0, ( real_t )0.0, ( real_t )0.0,
+        ( real_t )0.0, ( real_t )0.0,
+        ( real_t )0.0, ( real_t )0.0, ( real_t )0.0,
+        ( real_t )0.0, ( real_t )0.0, ( real_t )0.0,
+        ( real_t )0.0, ( real_t )0.0, ( real_t )0.0,
+        ( real_t )0.0, ( real_t )0.0, ( real_t )0.0
+    };
+
+    index_t indexes[] =
+    {
+        ( index_t )0, ( index_t )0, ( index_t )0, ( index_t )0
+    };
+
+    ptr_particles_t in_particles = SIXTRL_NULLPTR;
+    pb_iter_t part_it            = SIXTRL_NULLPTR;
+    be_iter_t line_begin         = SIXTRL_NULLPTR;
+    be_iter_t line_end           = SIXTRL_NULLPTR;
+
+    /* - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - */
+
+    SIXTRL_ASSERT( !NS(ManagedBuffer_needs_remapping)(
+        belem_buffer, slot_size ) );
+
+    line_begin = NS(ManagedBuffer_get_const_objects_index_begin)(
+        belem_buffer, slot_size );
+
+    SIXTRL_ASSERT( line_begin != SIXSTRL_NULLPTR );
+    SIXTRL_ASSERT( line_begin_idx <= line_end_idx );
+    SIXTRL_ASSERT( line_end_idx <= NS(ManagedBuffer_get_num_objects)(
+        belem_buffer, slot_size ) );
+
+    line_end   = line_begin + line_end_idx;
+    line_begin = line_begin + line_begin_idx;
+
+    SIXTRL_ASSERT( NS(BeamElements_objects_range_are_all_beam_elements)(
+        line_begin, line_end ) );
+
+    SIXTRL_ASSERT( !NS(ManagedBuffer_needs_remapping)( pbuffer, slot_size ) );
+
+    part_it = NS(ManagedBuffer_get_objects_index_begin)( pbuffer, slot_size );
+    SIXTRL_ASSERT( part_it != SIXTRL_NULLPTR );
+    SIXTRL_ASSERT( ( SIXTRL_UINT64_T )NS(ManagedBuffer_get_num_objects)(
+        pbuffer, slot_size ) > particle_set_index );
+
+    part_it = part_it + particle_set_index;
+
+    SIXTRL_ASSERT( NS(Object_get_type_id)( part_it ) ==
+                   NS(OBJECT_TYPE_PARTICLE) );
+
+    SIXTRL_ASSERT( NS(Object_get_begin_addr)( part_it ) >
+                   NS(buffer_addr_t)0u );
+
+    in_particles = ( ptr_particles_t )( uintptr_t
+        )NS(Object_get_begin_addr)( part_it );
+
+    SIXTRL_ASSERT( in_particles != SIXTRL_NULLPTR );
+    num_particles = in_particles->num_particles;
+
+    NS(OpenCl1x_init_optimized_priv_particle)( &particles, reals, indexes );
+    SIXTRL_ASSERT( particles.num_particles == ( num_element_t )1u );
+
+    for( ; particle_id < num_particles ; particle_id += stride )
+    {
+        NS(Particles_copy_from_generic_addr_data)(
+            &particles, 0, in_particles, particle_id );
+
+        NS(Track_particle_line)( &particles, 0, line_begin, line_end, fin );
+
+        NS(Particles_copy_to_generic_addr_data)(
+            in_particles, particle_id, &particles, 0 );
+    }
+
+    return;
+}
 
 __kernel void NS(Track_particles_single_turn_opt_pp_opencl)(
     SIXTRL_BUFFER_DATAPTR_DEC unsigned char* SIXTRL_RESTRICT particles_buffer,
@@ -76,7 +188,7 @@ __kernel void NS(Track_particles_single_turn_opt_pp_opencl)(
 
     ptr_particles_t in_particles = SIXTRL_NULLPTR;
 
-    real_t real_values[] =
+    real_t reals[] =
     {
         ( real_t )0.0, ( real_t )0.0, ( real_t )0.0,
         ( real_t )0.0, ( real_t )0.0,
@@ -86,38 +198,14 @@ __kernel void NS(Track_particles_single_turn_opt_pp_opencl)(
         ( real_t )0.0, ( real_t )0.0, ( real_t )0.0
     };
 
-    index_t index_values[] =
+    index_t indexes[] =
     {
         ( index_t )0, ( index_t )0, ( index_t )0, ( index_t )0
     };
 
     SIXTRL_PARTICLE_ARGPTR_DEC NS(Particles) particles;
 
-    NS(Particles_set_num_of_particles)(        &particles, 1u );
-    NS(Particles_assign_ptr_to_q0)(            &particles, &real_values[  0 ] );
-    NS(Particles_assign_ptr_to_mass0)(         &particles, &real_values[  1 ] );
-    NS(Particles_assign_ptr_to_beta0)(         &particles, &real_values[  2 ] );
-    NS(Particles_assign_ptr_to_gamma0)(        &particles, &real_values[  3 ] );
-    NS(Particles_assign_ptr_to_p0c)(           &particles, &real_values[  4 ] );
-
-    NS(Particles_assign_ptr_to_s)(             &particles, &real_values[  5 ] );
-    NS(Particles_assign_ptr_to_x)(             &particles, &real_values[  6 ] );
-    NS(Particles_assign_ptr_to_y)(             &particles, &real_values[  7 ] );
-    NS(Particles_assign_ptr_to_px)(            &particles, &real_values[  8 ] );
-    NS(Particles_assign_ptr_to_py)(            &particles, &real_values[  9 ] );
-    NS(Particles_assign_ptr_to_zeta)(          &particles, &real_values[ 10 ] );
-
-    NS(Particles_assign_ptr_to_psigma)(        &particles, &real_values[ 11 ] );
-    NS(Particles_assign_ptr_to_delta)(         &particles, &real_values[ 12 ] );
-    NS(Particles_assign_ptr_to_rpp)(           &particles, &real_values[ 13 ] );
-    NS(Particles_assign_ptr_to_rvv)(           &particles, &real_values[ 14 ] );
-    NS(Particles_assign_ptr_to_chi)(           &particles, &real_values[ 15 ] );
-    NS(Particles_assign_ptr_to_charge_ratio)(  &particles, &real_values[ 16 ] );
-
-    NS(Particles_assign_ptr_to_particle_id)(   &particles, &index_values[ 0 ] );
-    NS(Particles_assign_ptr_to_at_element_id)( &particles, &index_values[ 1 ] );
-    NS(Particles_assign_ptr_to_at_turn)(       &particles, &index_values[ 2 ] );
-    NS(Particles_assign_ptr_to_state)(         &particles, &index_values[ 3 ] );
+    NS(OpenCl1x_init_optimized_priv_particle)( &particles, reals, indexes );
 
     SIXTRL_ASSERT( be_begin != SIXTRL_NULLPTR );
     SIXTRL_ASSERT( be_end   != SIXTRL_NULLPTR );
@@ -125,7 +213,7 @@ __kernel void NS(Track_particles_single_turn_opt_pp_opencl)(
     SIXTRL_ASSERT( pb_it    != SIXTRL_NULLPTR );
 
     SIXTRL_ASSERT( NS(Object_get_type_id)( pb_it ) !=
-                   NS(OBJECT_TYPE_PARTICLES ) );
+                   NS(OBJECT_TYPE_PARTICLE) );
 
     SIXTRL_ASSERT( NS(Object_get_begin_addr)( pb_it ) !=
                    ( NS(buffer_addr_t) )0u );
@@ -213,7 +301,7 @@ __kernel void NS(Track_particles_until_turn_opt_pp_opencl)(
 
     ptr_particles_t in_particles = SIXTRL_NULLPTR;
 
-    real_t real_values[] =
+    real_t reals[] =
     {
         ( real_t )0.0, ( real_t )0.0, ( real_t )0.0,
         ( real_t )0.0, ( real_t )0.0,
@@ -223,38 +311,13 @@ __kernel void NS(Track_particles_until_turn_opt_pp_opencl)(
         ( real_t )0.0, ( real_t )0.0, ( real_t )0.0
     };
 
-    index_t index_values[] =
+    index_t indexes[] =
     {
         ( index_t )0, ( index_t )0, ( index_t )0, ( index_t )0
     };
 
     SIXTRL_PARTICLE_ARGPTR_DEC NS(Particles) particles;
-
-    NS(Particles_set_num_of_particles)(        &particles, 1u );
-    NS(Particles_assign_ptr_to_q0)(            &particles, &real_values[  0 ] );
-    NS(Particles_assign_ptr_to_mass0)(         &particles, &real_values[  1 ] );
-    NS(Particles_assign_ptr_to_beta0)(         &particles, &real_values[  2 ] );
-    NS(Particles_assign_ptr_to_gamma0)(        &particles, &real_values[  3 ] );
-    NS(Particles_assign_ptr_to_p0c)(           &particles, &real_values[  4 ] );
-
-    NS(Particles_assign_ptr_to_s)(             &particles, &real_values[  5 ] );
-    NS(Particles_assign_ptr_to_x)(             &particles, &real_values[  6 ] );
-    NS(Particles_assign_ptr_to_y)(             &particles, &real_values[  7 ] );
-    NS(Particles_assign_ptr_to_px)(            &particles, &real_values[  8 ] );
-    NS(Particles_assign_ptr_to_py)(            &particles, &real_values[  9 ] );
-    NS(Particles_assign_ptr_to_zeta)(          &particles, &real_values[ 10 ] );
-
-    NS(Particles_assign_ptr_to_psigma)(        &particles, &real_values[ 11 ] );
-    NS(Particles_assign_ptr_to_delta)(         &particles, &real_values[ 12 ] );
-    NS(Particles_assign_ptr_to_rpp)(           &particles, &real_values[ 13 ] );
-    NS(Particles_assign_ptr_to_rvv)(           &particles, &real_values[ 14 ] );
-    NS(Particles_assign_ptr_to_chi)(           &particles, &real_values[ 15 ] );
-    NS(Particles_assign_ptr_to_charge_ratio)(  &particles, &real_values[ 16 ] );
-
-    NS(Particles_assign_ptr_to_particle_id)(   &particles, &index_values[ 0 ] );
-    NS(Particles_assign_ptr_to_at_element_id)( &particles, &index_values[ 1 ] );
-    NS(Particles_assign_ptr_to_at_turn)(       &particles, &index_values[ 2 ] );
-    NS(Particles_assign_ptr_to_state)(         &particles, &index_values[ 3 ] );
+    NS(OpenCl1x_init_optimized_priv_particle)( &particles, reals, indexes );
 
     SIXTRL_ASSERT( be_begin != SIXTRL_NULLPTR );
     SIXTRL_ASSERT( be_end   != SIXTRL_NULLPTR );
@@ -262,10 +325,10 @@ __kernel void NS(Track_particles_until_turn_opt_pp_opencl)(
     SIXTRL_ASSERT( pb_it    != SIXTRL_NULLPTR );
 
     SIXTRL_ASSERT( NS(Object_get_type_id)( pb_it ) !=
-                   NS(OBJECT_TYPE_PARTICLES ) );
+                   NS(OBJECT_TYPE_PARTICLE) );
 
     SIXTRL_ASSERT( NS(Object_get_begin_addr)( pb_it ) !=
-                   ( NS(buffer_addr_t) )0u );
+                  ( NS(buffer_addr_t) )0u );
 
     SIXTRL_ASSERT( NS(ManagedBuffer_get_num_objects)(
         particles_buffer, slot_size ) >= ( buf_size_t )1u );
@@ -322,7 +385,7 @@ __kernel void NS(Track_particles_elem_by_elem_opt_pp_opencl)(
     typedef SIXTRL_BUFFER_DATAPTR_DEC NS(ParticlesGenericAddr)*
             ptr_particles_t;
 
-    SIXTRL_STATIC_VAR SIXTRL_INT32_T const ZERO_FLAG = ( SIXTRL_INT32_T )0u;
+    SIXTRL_STATIC_VAR NS(opencl_success_flag_t) const ZERO_FLAG = ( NS(opencl_success_flag_t) )0u;
 
     num_element_t idx = ( num_element_t )get_global_id( 0 );
     num_element_t num_particles = ( num_element_t )0u;
@@ -344,7 +407,7 @@ __kernel void NS(Track_particles_elem_by_elem_opt_pp_opencl)(
     ptr_particles_t in_particles           = SIXTRL_NULLPTR;
     ptr_particles_t elem_by_elem_particles = SIXTRL_NULLPTR;
 
-    real_t real_values[] =
+    real_t reals[] =
     {
         ( real_t )0.0, ( real_t )0.0, ( real_t )0.0,
         ( real_t )0.0, ( real_t )0.0,
@@ -354,38 +417,13 @@ __kernel void NS(Track_particles_elem_by_elem_opt_pp_opencl)(
         ( real_t )0.0, ( real_t )0.0, ( real_t )0.0
     };
 
-    index_t index_values[] =
+    index_t indexes[] =
     {
         ( index_t )0, ( index_t )0, ( index_t )0, ( index_t )0
     };
 
     SIXTRL_PARTICLE_ARGPTR_DEC NS(Particles) particles;
-
-    NS(Particles_set_num_of_particles)(        &particles, 1u );
-    NS(Particles_assign_ptr_to_q0)(            &particles, &real_values[  0 ] );
-    NS(Particles_assign_ptr_to_mass0)(         &particles, &real_values[  1 ] );
-    NS(Particles_assign_ptr_to_beta0)(         &particles, &real_values[  2 ] );
-    NS(Particles_assign_ptr_to_gamma0)(        &particles, &real_values[  3 ] );
-    NS(Particles_assign_ptr_to_p0c)(           &particles, &real_values[  4 ] );
-
-    NS(Particles_assign_ptr_to_s)(             &particles, &real_values[  5 ] );
-    NS(Particles_assign_ptr_to_x)(             &particles, &real_values[  6 ] );
-    NS(Particles_assign_ptr_to_y)(             &particles, &real_values[  7 ] );
-    NS(Particles_assign_ptr_to_px)(            &particles, &real_values[  8 ] );
-    NS(Particles_assign_ptr_to_py)(            &particles, &real_values[  9 ] );
-    NS(Particles_assign_ptr_to_zeta)(          &particles, &real_values[ 10 ] );
-
-    NS(Particles_assign_ptr_to_psigma)(        &particles, &real_values[ 11 ] );
-    NS(Particles_assign_ptr_to_delta)(         &particles, &real_values[ 12 ] );
-    NS(Particles_assign_ptr_to_rpp)(           &particles, &real_values[ 13 ] );
-    NS(Particles_assign_ptr_to_rvv)(           &particles, &real_values[ 14 ] );
-    NS(Particles_assign_ptr_to_chi)(           &particles, &real_values[ 15 ] );
-    NS(Particles_assign_ptr_to_charge_ratio)(  &particles, &real_values[ 16 ] );
-
-    NS(Particles_assign_ptr_to_particle_id)(   &particles, &index_values[ 0 ] );
-    NS(Particles_assign_ptr_to_at_element_id)( &particles, &index_values[ 1 ] );
-    NS(Particles_assign_ptr_to_at_turn)(       &particles, &index_values[ 2 ] );
-    NS(Particles_assign_ptr_to_state)(         &particles, &index_values[ 3 ] );
+    NS(OpenCl1x_init_optimized_priv_particle)( &particles, reals, indexes );
 
     SIXTRL_ASSERT( be_begin != SIXTRL_NULLPTR );
     SIXTRL_ASSERT( be_end   != SIXTRL_NULLPTR );
@@ -393,7 +431,7 @@ __kernel void NS(Track_particles_elem_by_elem_opt_pp_opencl)(
     SIXTRL_ASSERT( pb_it    != SIXTRL_NULLPTR );
 
     SIXTRL_ASSERT( NS(Object_get_type_id)( pb_it ) !=
-                   NS(OBJECT_TYPE_PARTICLES ) );
+                   NS(OBJECT_TYPE_PARTICLE) );
 
     SIXTRL_ASSERT( NS(Object_get_begin_addr)( pb_it ) !=
                    ( NS(buffer_addr_t) )0u );
@@ -423,7 +461,7 @@ __kernel void NS(Track_particles_elem_by_elem_opt_pp_opencl)(
     elem_by_elem_it = elem_by_elem_it + out_buffer_index_offset;
 
     SIXTRL_ASSERT( NS(Object_get_type_id)( elem_by_elem_it ) ==
-                   NS(OBJECT_TYPE_PARTICLES) );
+                   NS(OBJECT_TYPE_PARTICLE) );
 
     SIXTRL_ASSERT( NS(Object_get_begin_addr)( elem_by_elem_it ) !=
                    ( NS(buffer_addr_t) )0u );
@@ -446,7 +484,7 @@ __kernel void NS(Track_particles_elem_by_elem_opt_pp_opencl)(
         index_t particle_id   = ( index_t )0u;
         index_t turn          = ( index_t )0u;
 
-        SIXTRL_INT32_T success = NS(Particles_copy_from_generic_addr_data)(
+        NS(opencl_success_flag_t) success = NS(Particles_copy_from_generic_addr_data)(
             &particles, 0, in_particles, idx );
 
         start_elem_id = NS(Particles_get_at_element_id_value)( &particles, 0 );

--- a/sixtracklib/opencl/kernels/track_particles_optimized_priv_particles_debug.cl
+++ b/sixtracklib/opencl/kernels/track_particles_optimized_priv_particles_debug.cl
@@ -3,17 +3,27 @@
 
 #if !defined( SIXTRL_NO_INCLUDES )
     #include "sixtracklib/opencl/internal/default_compile_options.h"
+    #include "sixtracklib/opencl/internal/success_flag.h"
+    #include "sixtracklib/opencl/internal/optimized_priv_particle.h"
 
     #include "sixtracklib/common/definitions.h"
     #include "sixtracklib/common/buffer/managed_buffer_minimal.h"
     #include "sixtracklib/common/buffer/managed_buffer_remap.h"
+    #include "sixtracklib/common/internal/buffer_object_defines.h"
     #include "sixtracklib/common/internal/particles_defines.h"
     #include "sixtracklib/common/output/elem_by_elem_config.h"
     #include "sixtracklib/common/particles.h"
     #include "sixtracklib/common/track.h"
 #endif /* !defined( SIXTRL_NO_INCLUDES ) */
 
-#pragma OPENCL_EXTENSION cl_khr_int32_extended_atomics
+__kernel void NS(Track_particle_line_opt_pp_debug_opencl)(
+    SIXTRL_BUFFER_DATAPTR_DEC unsigned char* SIXTRL_RESTRICT pbuffer,
+    SIXTRL_UINT64_T const particle_set_index,
+    SIXTRL_BUFFER_DATAPTR_DEC unsigned char const* SIXTRL_RESTRICT belem_buffer,
+    SIXTRL_UINT64_T const line_begin_idx, SIXTRL_UINT64_T const line_end_idx,
+    SIXTRL_UINT64_T const finish_turn_value,
+    SIXTRL_BUFFER_DATAPTR_DEC NS(opencl_success_flag_t)*
+        SIXTRL_RESTRICT ptr_success_flag );
 
 __kernel void NS(Track_particles_single_turn_opt_pp_debug_opencl)(
     SIXTRL_BUFFER_DATAPTR_DEC unsigned char*
@@ -21,7 +31,7 @@ __kernel void NS(Track_particles_single_turn_opt_pp_debug_opencl)(
     SIXTRL_BUFFER_DATAPTR_DEC unsigned char const*
         SIXTRL_RESTRICT belem_buffer,
     SIXTRL_INT64_T const increment_turn,
-    SIXTRL_BUFFER_DATAPTR_DEC SIXTRL_INT32_T*
+    SIXTRL_BUFFER_DATAPTR_DEC NS(opencl_success_flag_t)*
         SIXTRL_RESTRICT ptr_success_flag );
 
 __kernel void NS(Track_particles_until_turn_opt_pp_debug_opencl)(
@@ -29,7 +39,7 @@ __kernel void NS(Track_particles_until_turn_opt_pp_debug_opencl)(
         SIXTRL_RESTRICT particles_buffer,
     SIXTRL_BUFFER_DATAPTR_DEC unsigned char const*
         SIXTRL_RESTRICT belem_buffer, SIXTRL_INT64_T const until_turn,
-    SIXTRL_BUFFER_DATAPTR_DEC SIXTRL_INT32_T*
+    SIXTRL_BUFFER_DATAPTR_DEC NS(opencl_success_flag_t)*
         SIXTRL_RESTRICT ptr_success_flag );
 
 __kernel void NS(Track_particles_elem_by_elem_opt_pp_debug_opencl)(
@@ -43,16 +53,170 @@ __kernel void NS(Track_particles_elem_by_elem_opt_pp_debug_opencl)(
         SIXTRL_RESTRICT elem_by_elem_config,
     SIXTRL_INT64_T const until_turn,
     SIXTRL_UINT64_T const out_buffer_index_offset,
-    SIXTRL_BUFFER_DATAPTR_DEC SIXTRL_INT32_T*
+    SIXTRL_BUFFER_DATAPTR_DEC NS(opencl_success_flag_t)*
         SIXTRL_RESTRICT ptr_success_flag );
 
 /* ========================================================================= */
+
+__kernel void NS(Track_particle_line_opt_pp_debug_opencl)(
+    SIXTRL_BUFFER_DATAPTR_DEC unsigned char* SIXTRL_RESTRICT pbuffer,
+    SIXTRL_UINT64_T const particle_set_index,
+    SIXTRL_BUFFER_DATAPTR_DEC unsigned char const* SIXTRL_RESTRICT belem_buffer,
+    SIXTRL_UINT64_T const line_begin_idx, SIXTRL_UINT64_T const line_end_idx,
+    SIXTRL_UINT64_T const finish_turn_value,
+    SIXTRL_BUFFER_DATAPTR_DEC NS(opencl_success_flag_t)*
+        SIXTRL_RESTRICT ptr_success_flag )
+{
+    typedef NS(buffer_size_t)           buf_size_t;
+    typedef NS(particle_num_elements_t) num_element_t;
+    typedef NS(particle_real_t)         real_t;
+    typedef NS(particle_index_t)        index_t;
+
+    typedef SIXTRL_BUFFER_OBJ_ARGPTR_DEC NS(Object) const* be_iter_t;
+    typedef SIXTRL_BUFFER_OBJ_ARGPTR_DEC NS(Object)*       obj_iter_t;
+
+    typedef SIXTRL_BUFFER_DATAPTR_DEC NS(ParticlesGenericAddr)*
+            ptr_particles_t;
+
+    SIXTRL_STATIC_VAR NS(opencl_success_flag_t) const ZERO_FLAG =
+        ( NS(opencl_success_flag_t) )0u;
+
+    NS(opencl_success_flag_t) success_flag = ( NS(opencl_success_flag_t) )-1;
+
+    buf_size_t const slot_size  = ( buf_size_t )8u;
+    num_element_t particle_id   = ( num_element_t )get_global_id( 0 );
+    num_element_t const stride  = ( num_element_t )get_global_size( 0 );
+    num_element_t num_particles = ( num_element_t )0u;
+
+    SIXTRL_PARTICLE_ARGPTR_DEC NS(Particles) particles;
+
+    real_t reals[] =
+    {
+        ( real_t )0.0, ( real_t )0.0, ( real_t )0.0,
+        ( real_t )0.0, ( real_t )0.0,
+        ( real_t )0.0, ( real_t )0.0, ( real_t )0.0,
+        ( real_t )0.0, ( real_t )0.0, ( real_t )0.0,
+        ( real_t )0.0, ( real_t )0.0, ( real_t )0.0,
+        ( real_t )0.0, ( real_t )0.0, ( real_t )0.0
+    };
+
+    index_t indexes[] =
+    {
+        ( index_t )0, ( index_t )0, ( index_t )0, ( index_t )0
+    };
+
+    ptr_particles_t in_particles = SIXTRL_NULLPTR;
+    be_iter_t line_begin    = SIXTRL_NULLPTR;
+    be_iter_t line_end      = SIXTRL_NULLPTR;
+    obj_iter_t particles_it = SIXTRL_NULLPTR;
+
+    /* - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - */
+
+    if( ( !NS(ManagedBuffer_needs_remapping)( belem_buffer, slot_size ) ) &&
+        ( line_begin_idx <= line_end_idx ) &&
+        ( line_end_idx <= NS(ManagedBuffer_get_num_objects)(
+            belem_buffer, slot_size ) ) )
+    {
+        line_begin = NS(ManagedBuffer_get_const_objects_index_begin)(
+            belem_buffer, slot_size );
+
+        if( line_begin != SIXTRL_NULLPTR )
+        {
+            line_end   = line_begin + line_end_idx;
+            line_begin = line_begin + line_begin_idx;
+
+            if( !NS(BeamElements_objects_range_are_all_beam_elements)(
+                    line_begin, line_end ) )
+            {
+                success_flag = ( NS(opencl_success_flag_t) )-8;
+            }
+        }
+        else
+        {
+            success_flag = ( NS(opencl_success_flag_t) )-4;
+        }
+    }
+    else
+    {
+        success_flag = ( NS(opencl_success_flag_t) )-2;
+    }
+
+    /* - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - */
+
+    if( ( success_flag == ZERO_FLAG ) &&
+        ( !NS(ManagedBuffer_needs_remapping)( pbuffer, slot_size ) ) &&
+        ( ( SIXTRL_UINT64_T )NS(ManagedBuffer_get_num_objects)(
+            pbuffer, slot_size ) > particle_set_index ) )
+    {
+        particles_it = NS(ManagedBuffer_get_objects_index_begin)(
+            pbuffer, slot_size );
+
+        if( particles_it != SIXTRL_NULLPTR )
+        {
+            particles_it = particles_it + particle_set_index;
+
+            if( ( NS(Object_get_type_id)( particles_it ) ==
+                  NS(OBJECT_TYPE_PARTICLE) ) &&
+                ( NS(Object_get_begin_addr)( particles_it ) !=
+                  ( NS(buffer_addr_t) )0u ) )
+            {
+                in_particles = ( ptr_particles_t )( uintptr_t
+                    )NS(Object_get_begin_addr)( particles_it );
+            }
+            else
+            {
+                success_flag = ( NS(opencl_success_flag_t) )-64;
+            }
+        }
+        else
+        {
+            success_flag = ( NS(opencl_success_flag_t) )-32;
+        }
+    }
+    else if( success_flag == ZERO_FLAG )
+    {
+        success_flag = ( NS(opencl_success_flag_t) )-16;
+    }
+
+    /* - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - */
+
+    if( ( success_flag == ZERO_FLAG ) && ( in_particles != SIXTRL_NULLPTR ) &&
+        ( in_particles->num_particles > ( num_element_t )0u ) )
+    {
+        num_particles = in_particles->num_particles;
+
+        NS(OpenCl1x_init_optimized_priv_particle)( &particles, reals, indexes );
+    }
+    else if( success_flag == ZERO_FLAG )
+    {
+        success_flag = ( NS(opencl_success_flag_t) )-128;
+    }
+
+    if( success_flag == ZERO_FLAG )
+    {
+        for( ; particle_id < num_particles ; particle_id += stride )
+        {
+            success_flag |= ( NS(Particles_copy_from_generic_addr_data)(
+                &particles, 0, in_particles, particle_id ) == 0 ) ? 0 : -256;
+
+            success_flag |= ( NS(Track_particle_line)( &particles, 0,
+                line_begin, line_end, ( finish_turn_value > 0u ) ) == 0 )
+                    ?  0 : -512;
+
+            success_flag |= ( NS(Particles_copy_to_generic_addr_data)(
+                in_particles, particle_id, &particles, 0 ) == 0 ) ? 0 : -1024;
+        }
+    }
+
+    NS(OpenCl1x_collect_success_flag_value)( ptr_success_flag, success_flag );
+    return;
+}
 
 __kernel void NS(Track_particles_single_turn_opt_pp_debug_opencl)(
     SIXTRL_BUFFER_DATAPTR_DEC unsigned char* SIXTRL_RESTRICT particles_buffer,
     SIXTRL_BUFFER_DATAPTR_DEC unsigned char const*
         SIXTRL_RESTRICT belem_buffer, SIXTRL_INT64_T const increment_turn,
-    SIXTRL_BUFFER_DATAPTR_DEC SIXTRL_INT32_T*
+    SIXTRL_BUFFER_DATAPTR_DEC NS(opencl_success_flag_t)*
         SIXTRL_RESTRICT ptr_success_flag )
 {
     typedef NS(buffer_size_t)           buf_size_t;
@@ -69,9 +233,10 @@ __kernel void NS(Track_particles_single_turn_opt_pp_debug_opencl)(
     typedef SIXTRL_BUFFER_DATAPTR_DEC NS(ParticlesGenericAddr)*
             ptr_particles_t;
 
-    SIXTRL_STATIC_VAR SIXTRL_INT32_T const ZERO_FLAG = ( SIXTRL_INT32_T )0u;
+    SIXTRL_STATIC_VAR NS(opencl_success_flag_t) const ZERO_FLAG =
+        ( NS(opencl_success_flag_t) )0u;
 
-    SIXTRL_INT32_T success = ( SIXTRL_INT32_T )-1;
+    NS(opencl_success_flag_t) success = ( NS(opencl_success_flag_t) )-1;
     buf_size_t const  slot_size = ( buf_size_t )8u;
 
     if( ( !NS(ManagedBuffer_needs_remapping)(
@@ -97,7 +262,7 @@ __kernel void NS(Track_particles_single_turn_opt_pp_debug_opencl)(
 
         ptr_particles_t in_particles = SIXTRL_NULLPTR;
 
-        real_t real_values[] =
+        real_t reals[] =
         {
             ( real_t )0.0, ( real_t )0.0, ( real_t )0.0,
             ( real_t )0.0, ( real_t )0.0,
@@ -107,38 +272,14 @@ __kernel void NS(Track_particles_single_turn_opt_pp_debug_opencl)(
             ( real_t )0.0, ( real_t )0.0, ( real_t )0.0
         };
 
-        index_t index_values[] =
+        index_t indexes[] =
         {
             ( index_t )0, ( index_t )0, ( index_t )0, ( index_t )0
         };
 
         SIXTRL_PARTICLE_ARGPTR_DEC NS(Particles) particles;
 
-        NS(Particles_set_num_of_particles)(        &particles, 1u );
-        NS(Particles_assign_ptr_to_q0)(            &particles, &real_values[  0 ] );
-        NS(Particles_assign_ptr_to_mass0)(         &particles, &real_values[  1 ] );
-        NS(Particles_assign_ptr_to_beta0)(         &particles, &real_values[  2 ] );
-        NS(Particles_assign_ptr_to_gamma0)(        &particles, &real_values[  3 ] );
-        NS(Particles_assign_ptr_to_p0c)(           &particles, &real_values[  4 ] );
-
-        NS(Particles_assign_ptr_to_s)(             &particles, &real_values[  5 ] );
-        NS(Particles_assign_ptr_to_x)(             &particles, &real_values[  6 ] );
-        NS(Particles_assign_ptr_to_y)(             &particles, &real_values[  7 ] );
-        NS(Particles_assign_ptr_to_px)(            &particles, &real_values[  8 ] );
-        NS(Particles_assign_ptr_to_py)(            &particles, &real_values[  9 ] );
-        NS(Particles_assign_ptr_to_zeta)(          &particles, &real_values[ 10 ] );
-
-        NS(Particles_assign_ptr_to_psigma)(        &particles, &real_values[ 11 ] );
-        NS(Particles_assign_ptr_to_delta)(         &particles, &real_values[ 12 ] );
-        NS(Particles_assign_ptr_to_rpp)(           &particles, &real_values[ 13 ] );
-        NS(Particles_assign_ptr_to_rvv)(           &particles, &real_values[ 14 ] );
-        NS(Particles_assign_ptr_to_chi)(           &particles, &real_values[ 15 ] );
-        NS(Particles_assign_ptr_to_charge_ratio)(  &particles, &real_values[ 16 ] );
-
-        NS(Particles_assign_ptr_to_particle_id)(   &particles, &index_values[ 0 ] );
-        NS(Particles_assign_ptr_to_at_element_id)( &particles, &index_values[ 1 ] );
-        NS(Particles_assign_ptr_to_at_turn)(       &particles, &index_values[ 2 ] );
-        NS(Particles_assign_ptr_to_state)(         &particles, &index_values[ 3 ] );
+        NS(OpenCl1x_init_optimized_priv_particle)( &particles, reals, indexes );
 
         SIXTRL_ASSERT( be_begin != SIXTRL_NULLPTR );
         SIXTRL_ASSERT( be_end   != SIXTRL_NULLPTR );
@@ -146,7 +287,7 @@ __kernel void NS(Track_particles_single_turn_opt_pp_debug_opencl)(
         SIXTRL_ASSERT( pb_it    != SIXTRL_NULLPTR );
 
         SIXTRL_ASSERT( NS(Object_get_type_id)( pb_it ) !=
-                       NS(OBJECT_TYPE_PARTICLES ) );
+                       NS(OBJECT_TYPE_PARTICLE) );
 
         SIXTRL_ASSERT( NS(Object_get_begin_addr)( pb_it ) !=
                        ( NS(buffer_addr_t) )0u );
@@ -207,23 +348,19 @@ __kernel void NS(Track_particles_single_turn_opt_pp_debug_opencl)(
     }
     else if( NS(ManagedBuffer_needs_remapping)( particles_buffer, slot_size) )
     {
-        success |= ( SIXTRL_INT32_T )-2;
+        success |= ( NS(opencl_success_flag_t) )-2;
     }
     else if( NS(ManagedBuffer_get_num_objects)(
                 particles_buffer, slot_size ) < ( buf_size_t )1u )
     {
-        success |= ( SIXTRL_INT32_T )-4;
+        success |= ( NS(opencl_success_flag_t) )-4;
     }
     else if( NS(ManagedBuffer_needs_remapping)( belem_buffer, slot_size ) )
     {
-        success |= ( SIXTRL_INT32_T )-8;
+        success |= ( NS(opencl_success_flag_t) )-8;
     }
 
-    if( ( success == 0 ) && ( ptr_success_flag != SIXTRL_NULLPTR ) )
-    {
-        atomic_or( ptr_success_flag, success );
-    }
-
+    NS(OpenCl1x_collect_success_flag_value)( ptr_success_flag, success );
     return;
 }
 
@@ -233,7 +370,7 @@ __kernel void NS(Track_particles_until_turn_opt_pp_debug_opencl)(
     SIXTRL_BUFFER_DATAPTR_DEC unsigned char* SIXTRL_RESTRICT particles_buffer,
     SIXTRL_BUFFER_DATAPTR_DEC unsigned char const*
         SIXTRL_RESTRICT belem_buffer, SIXTRL_INT64_T const until_turn,
-    SIXTRL_BUFFER_DATAPTR_DEC SIXTRL_INT32_T*
+    SIXTRL_BUFFER_DATAPTR_DEC NS(opencl_success_flag_t)*
         SIXTRL_RESTRICT ptr_success_flag )
 {
     typedef NS(buffer_size_t)           buf_size_t;
@@ -250,10 +387,11 @@ __kernel void NS(Track_particles_until_turn_opt_pp_debug_opencl)(
     typedef SIXTRL_BUFFER_DATAPTR_DEC NS(ParticlesGenericAddr)*
             ptr_particles_t;
 
-    SIXTRL_STATIC_VAR SIXTRL_INT32_T const ZERO_FLAG = ( SIXTRL_INT32_T )0u;
+    SIXTRL_STATIC_VAR NS(opencl_success_flag_t) const ZERO_FLAG =
+        ( NS(opencl_success_flag_t) )0u;
 
     buf_size_t const  slot_size = ( buf_size_t )8u;
-    SIXTRL_INT32_T success_flag = ( SIXTRL_INT32_T )-1;
+    NS(opencl_success_flag_t) success_flag = ( NS(opencl_success_flag_t) )-1;
 
     if( ( !NS(ManagedBuffer_needs_remapping)(
                 particles_buffer, slot_size ) ) &&
@@ -279,7 +417,7 @@ __kernel void NS(Track_particles_until_turn_opt_pp_debug_opencl)(
 
         ptr_particles_t in_particles = SIXTRL_NULLPTR;
 
-        real_t real_values[] =
+        real_t reals[] =
         {
             ( real_t )0.0, ( real_t )0.0, ( real_t )0.0,
             ( real_t )0.0, ( real_t )0.0,
@@ -289,38 +427,13 @@ __kernel void NS(Track_particles_until_turn_opt_pp_debug_opencl)(
             ( real_t )0.0, ( real_t )0.0, ( real_t )0.0
         };
 
-        index_t index_values[] =
+        index_t indexes[] =
         {
             ( index_t )0, ( index_t )0, ( index_t )0, ( index_t )0
         };
 
         SIXTRL_PARTICLE_ARGPTR_DEC NS(Particles) particles;
-
-        NS(Particles_set_num_of_particles)(        &particles, 1u );
-        NS(Particles_assign_ptr_to_q0)(            &particles, &real_values[  0 ] );
-        NS(Particles_assign_ptr_to_mass0)(         &particles, &real_values[  1 ] );
-        NS(Particles_assign_ptr_to_beta0)(         &particles, &real_values[  2 ] );
-        NS(Particles_assign_ptr_to_gamma0)(        &particles, &real_values[  3 ] );
-        NS(Particles_assign_ptr_to_p0c)(           &particles, &real_values[  4 ] );
-
-        NS(Particles_assign_ptr_to_s)(             &particles, &real_values[  5 ] );
-        NS(Particles_assign_ptr_to_x)(             &particles, &real_values[  6 ] );
-        NS(Particles_assign_ptr_to_y)(             &particles, &real_values[  7 ] );
-        NS(Particles_assign_ptr_to_px)(            &particles, &real_values[  8 ] );
-        NS(Particles_assign_ptr_to_py)(            &particles, &real_values[  9 ] );
-        NS(Particles_assign_ptr_to_zeta)(          &particles, &real_values[ 10 ] );
-
-        NS(Particles_assign_ptr_to_psigma)(        &particles, &real_values[ 11 ] );
-        NS(Particles_assign_ptr_to_delta)(         &particles, &real_values[ 12 ] );
-        NS(Particles_assign_ptr_to_rpp)(           &particles, &real_values[ 13 ] );
-        NS(Particles_assign_ptr_to_rvv)(           &particles, &real_values[ 14 ] );
-        NS(Particles_assign_ptr_to_chi)(           &particles, &real_values[ 15 ] );
-        NS(Particles_assign_ptr_to_charge_ratio)(  &particles, &real_values[ 16 ] );
-
-        NS(Particles_assign_ptr_to_particle_id)(   &particles, &index_values[ 0 ] );
-        NS(Particles_assign_ptr_to_at_element_id)( &particles, &index_values[ 1 ] );
-        NS(Particles_assign_ptr_to_at_turn)(       &particles, &index_values[ 2 ] );
-        NS(Particles_assign_ptr_to_state)(         &particles, &index_values[ 3 ] );
+        NS(OpenCl1x_init_optimized_priv_particle)( &particles, reals, indexes );
 
         SIXTRL_ASSERT( be_begin != SIXTRL_NULLPTR );
         SIXTRL_ASSERT( be_end   != SIXTRL_NULLPTR );
@@ -328,7 +441,7 @@ __kernel void NS(Track_particles_until_turn_opt_pp_debug_opencl)(
         SIXTRL_ASSERT( pb_it    != SIXTRL_NULLPTR );
 
         SIXTRL_ASSERT( NS(Object_get_type_id)( pb_it ) !=
-                       NS(OBJECT_TYPE_PARTICLES ) );
+                       NS(OBJECT_TYPE_PARTICLE) );
 
         SIXTRL_ASSERT( NS(Object_get_begin_addr)( pb_it ) !=
                        ( NS(buffer_addr_t) )0u );
@@ -372,23 +485,19 @@ __kernel void NS(Track_particles_until_turn_opt_pp_debug_opencl)(
     }
     else if( NS(ManagedBuffer_needs_remapping)( particles_buffer, slot_size) )
     {
-        success_flag |= ( SIXTRL_INT32_T )-2;
+        success_flag |= ( NS(opencl_success_flag_t) )-2;
     }
     else if( NS(ManagedBuffer_get_num_objects)(
                 particles_buffer, slot_size ) != ( buf_size_t )1u )
     {
-        success_flag |= ( SIXTRL_INT32_T )-4;
+        success_flag |= ( NS(opencl_success_flag_t) )-4;
     }
     else if( NS(ManagedBuffer_needs_remapping)( belem_buffer, slot_size ) )
     {
-        success_flag |= ( SIXTRL_INT32_T )-8;
+        success_flag |= ( NS(opencl_success_flag_t) )-8;
     }
 
-    if( ( success_flag != 0 ) && ( ptr_success_flag != SIXTRL_NULLPTR ) )
-    {
-        atomic_or( ptr_success_flag, success_flag );
-    }
-
+    NS(OpenCl1x_collect_success_flag_value)( ptr_success_flag, success_flag );
     return;
 }
 
@@ -404,7 +513,7 @@ __kernel void NS(Track_particles_elem_by_elem_opt_pp_debug_opencl)(
     SIXTRL_ELEM_BY_ELEM_CONFIG_ARGPTR_DEC NS(ElemByElemConfig)*
         SIXTRL_RESTRICT elem_by_elem_config, SIXTRL_INT64_T const until_turn,
     SIXTRL_UINT64_T const out_buffer_index_offset,
-    SIXTRL_BUFFER_DATAPTR_DEC SIXTRL_INT32_T*
+    SIXTRL_BUFFER_DATAPTR_DEC NS(opencl_success_flag_t)*
         SIXTRL_RESTRICT ptr_success_flag )
 {
     typedef NS(buffer_size_t)                         buf_size_t;
@@ -419,9 +528,9 @@ __kernel void NS(Track_particles_elem_by_elem_opt_pp_debug_opencl)(
     typedef SIXTRL_BUFFER_DATAPTR_DEC NS(ParticlesGenericAddr)*
             ptr_particles_t;
 
-    SIXTRL_STATIC_VAR SIXTRL_INT32_T const ZERO_FLAG = ( SIXTRL_INT32_T )0u;
+    SIXTRL_STATIC_VAR NS(opencl_success_flag_t) const ZERO_FLAG = ( NS(opencl_success_flag_t) )0u;
 
-    SIXTRL_INT32_T success = ( SIXTRL_INT32_T )-1;
+    NS(opencl_success_flag_t) success = ( NS(opencl_success_flag_t) )-1;
     buf_size_t const  slot_size = ( buf_size_t )8u;
 
     if( ( !NS(ManagedBuffer_needs_remapping)( particles_buffer, slot_size ) ) &&
@@ -450,7 +559,7 @@ __kernel void NS(Track_particles_elem_by_elem_opt_pp_debug_opencl)(
         ptr_particles_t in_particles           = SIXTRL_NULLPTR;
         ptr_particles_t elem_by_elem_particles = SIXTRL_NULLPTR;
 
-        real_t real_values[] =
+        real_t reals[] =
         {
             ( real_t )0.0, ( real_t )0.0, ( real_t )0.0,
             ( real_t )0.0, ( real_t )0.0,
@@ -460,38 +569,13 @@ __kernel void NS(Track_particles_elem_by_elem_opt_pp_debug_opencl)(
             ( real_t )0.0, ( real_t )0.0, ( real_t )0.0
         };
 
-        index_t index_values[] =
+        index_t indexes[] =
         {
             ( index_t )0, ( index_t )0, ( index_t )0, ( index_t )0
         };
 
         SIXTRL_PARTICLE_ARGPTR_DEC NS(Particles) particles;
-
-        NS(Particles_set_num_of_particles)(        &particles, 1u );
-        NS(Particles_assign_ptr_to_q0)(            &particles, &real_values[  0 ] );
-        NS(Particles_assign_ptr_to_mass0)(         &particles, &real_values[  1 ] );
-        NS(Particles_assign_ptr_to_beta0)(         &particles, &real_values[  2 ] );
-        NS(Particles_assign_ptr_to_gamma0)(        &particles, &real_values[  3 ] );
-        NS(Particles_assign_ptr_to_p0c)(           &particles, &real_values[  4 ] );
-
-        NS(Particles_assign_ptr_to_s)(             &particles, &real_values[  5 ] );
-        NS(Particles_assign_ptr_to_x)(             &particles, &real_values[  6 ] );
-        NS(Particles_assign_ptr_to_y)(             &particles, &real_values[  7 ] );
-        NS(Particles_assign_ptr_to_px)(            &particles, &real_values[  8 ] );
-        NS(Particles_assign_ptr_to_py)(            &particles, &real_values[  9 ] );
-        NS(Particles_assign_ptr_to_zeta)(          &particles, &real_values[ 10 ] );
-
-        NS(Particles_assign_ptr_to_psigma)(        &particles, &real_values[ 11 ] );
-        NS(Particles_assign_ptr_to_delta)(         &particles, &real_values[ 12 ] );
-        NS(Particles_assign_ptr_to_rpp)(           &particles, &real_values[ 13 ] );
-        NS(Particles_assign_ptr_to_rvv)(           &particles, &real_values[ 14 ] );
-        NS(Particles_assign_ptr_to_chi)(           &particles, &real_values[ 15 ] );
-        NS(Particles_assign_ptr_to_charge_ratio)(  &particles, &real_values[ 16 ] );
-
-        NS(Particles_assign_ptr_to_particle_id)(   &particles, &index_values[ 0 ] );
-        NS(Particles_assign_ptr_to_at_element_id)( &particles, &index_values[ 1 ] );
-        NS(Particles_assign_ptr_to_at_turn)(       &particles, &index_values[ 2 ] );
-        NS(Particles_assign_ptr_to_state)(         &particles, &index_values[ 3 ] );
+        NS(OpenCl1x_init_optimized_priv_particle)( &particles, reals, indexes );
 
         SIXTRL_ASSERT( be_begin != SIXTRL_NULLPTR );
         SIXTRL_ASSERT( be_end   != SIXTRL_NULLPTR );
@@ -499,7 +583,7 @@ __kernel void NS(Track_particles_elem_by_elem_opt_pp_debug_opencl)(
         SIXTRL_ASSERT( pb_it    != SIXTRL_NULLPTR );
 
         SIXTRL_ASSERT( NS(Object_get_type_id)( pb_it ) !=
-                       NS(OBJECT_TYPE_PARTICLES ) );
+                       NS(OBJECT_TYPE_PARTICLE) );
 
         SIXTRL_ASSERT( NS(Object_get_begin_addr)( pb_it ) !=
                        ( NS(buffer_addr_t) )0u );
@@ -529,7 +613,7 @@ __kernel void NS(Track_particles_elem_by_elem_opt_pp_debug_opencl)(
         elem_by_elem_it = elem_by_elem_it + out_buffer_index_offset;
 
         SIXTRL_ASSERT( NS(Object_get_type_id)( elem_by_elem_it ) ==
-                       NS(OBJECT_TYPE_PARTICLES) );
+                       NS(OBJECT_TYPE_PARTICLE) );
 
         SIXTRL_ASSERT( NS(Object_get_begin_addr)( elem_by_elem_it ) !=
                        ( NS(buffer_addr_t) )0u );
@@ -611,28 +695,24 @@ __kernel void NS(Track_particles_elem_by_elem_opt_pp_debug_opencl)(
     }
     else if( NS(ManagedBuffer_needs_remapping)( particles_buffer, slot_size) )
     {
-        success |= ( SIXTRL_INT32_T )-2;
+        success |= ( NS(opencl_success_flag_t) )-2;
     }
     else if( NS(ManagedBuffer_get_num_objects)(
                 particles_buffer, slot_size ) < ( buf_size_t )1u )
     {
-        success |= ( SIXTRL_INT32_T )-4;
+        success |= ( NS(opencl_success_flag_t) )-4;
     }
     else if( NS(ManagedBuffer_needs_remapping)( belem_buffer, slot_size ) )
     {
-        success |= ( SIXTRL_INT32_T )-8;
+        success |= ( NS(opencl_success_flag_t) )-8;
     }
     else if( NS(ManagedBuffer_needs_remapping)(
             elem_by_elem_buffer, slot_size ) )
     {
-        success |= ( SIXTRL_INT32_T )-16;
+        success |= ( NS(opencl_success_flag_t) )-16;
     }
 
-    if( ( success != 0 ) && ( ptr_success_flag != SIXTRL_NULLPTR ) )
-    {
-        atomic_or( ptr_success_flag, success );
-    }
-
+    NS(OpenCl1x_collect_success_flag_value)( ptr_success_flag, success );
     return;
 }
 

--- a/sixtracklib/opencl/kernels/track_particles_optimized_priv_particles_debug.cl
+++ b/sixtracklib/opencl/kernels/track_particles_optimized_priv_particles_debug.cl
@@ -16,7 +16,7 @@
     #include "sixtracklib/common/track.h"
 #endif /* !defined( SIXTRL_NO_INCLUDES ) */
 
-__kernel void NS(Track_particle_line_opt_pp_debug_opencl)(
+__kernel void NS(Track_particles_line_opt_pp_debug_opencl)(
     SIXTRL_BUFFER_DATAPTR_DEC unsigned char* SIXTRL_RESTRICT pbuffer,
     SIXTRL_UINT64_T const particle_set_index,
     SIXTRL_BUFFER_DATAPTR_DEC unsigned char const* SIXTRL_RESTRICT belem_buffer,
@@ -58,7 +58,7 @@ __kernel void NS(Track_particles_elem_by_elem_opt_pp_debug_opencl)(
 
 /* ========================================================================= */
 
-__kernel void NS(Track_particle_line_opt_pp_debug_opencl)(
+__kernel void NS(Track_particles_line_opt_pp_debug_opencl)(
     SIXTRL_BUFFER_DATAPTR_DEC unsigned char* SIXTRL_RESTRICT pbuffer,
     SIXTRL_UINT64_T const particle_set_index,
     SIXTRL_BUFFER_DATAPTR_DEC unsigned char const* SIXTRL_RESTRICT belem_buffer,

--- a/sixtracklib/opencl/track_job_cl.h
+++ b/sixtracklib/opencl/track_job_cl.h
@@ -204,6 +204,10 @@ namespace SIXTRL_CXX_NAMESPACE
         SIXTRL_HOST_FN virtual track_status_t doTrackElemByElem(
             size_type const until_turn ) override;
 
+        SIXTRL_HOST_FN virtual track_status_t doTrackLine(
+            size_type const line_begin_idx, size_type const line_end_idx,
+            bool const finish_turn ) override;
+
         SIXTRL_HOST_FN virtual void doCollect() override;
 
         SIXTRL_HOST_FN virtual void doParseConfigStr(
@@ -285,6 +289,12 @@ namespace SIXTRL_CXX_NAMESPACE
     SIXTRL_HOST_FN TrackJobCl::track_status_t trackElemByElem(
         TrackJobCl& SIXTRL_RESTRICT_REF job,
         TrackJobCl::size_type const until_turn_elem_by_elem ) SIXTRL_NOEXCEPT;
+
+    SIXTRL_HOST_FN TrackJobCl::track_status_t trackLine(
+        TrackJobCl& SIXTRL_RESTRICT_REF job,
+        TrackJobCl::size_type const line_begin_idx,
+        TrackJobCl::size_type const line_end_idx,
+        bool const finish_turn = false ) SIXTRL_NOEXCEPT;
 }
 
 typedef SIXTRL_CXX_NAMESPACE::TrackJobCl    NS(TrackJobCl);
@@ -376,6 +386,13 @@ SIXTRL_EXTERN SIXTRL_HOST_FN NS(track_status_t)
 NS(TrackJobCl_track_elem_by_elem)(
     NS(TrackJobCl)* SIXTRL_RESTRICT track_job,
     NS(buffer_size_t) const until_turn );
+
+SIXTRL_EXTERN SIXTRL_HOST_FN NS(track_status_t)
+NS(TrackJobCl_track_line)(
+    NS(TrackJobCl)* SIXTRL_RESTRICT track_job,
+    NS(buffer_size_t) const line_begin_idx,
+    NS(buffer_size_t) const line_end_idx,
+    bool const finish_turn );
 
 SIXTRL_EXTERN SIXTRL_HOST_FN void NS(TrackJobCl_collect)(
     NS(TrackJobCl)* SIXTRL_RESTRICT track_job );

--- a/sixtracklib/opencl/track_job_cl.h
+++ b/sixtracklib/opencl/track_job_cl.h
@@ -58,6 +58,8 @@ namespace SIXTRL_CXX_NAMESPACE
         using elem_by_elem_config_t = _base_t::elem_by_elem_config_t;
         using track_status_t        = _base_t::track_status_t;
         using type_t                = _base_t::type_t;
+        using output_buffer_flag_t  = _base_t::output_buffer_flag_t;
+        using collect_flag_t        = _base_t::collect_flag_t;
 
         using cl_arg_t              = SIXTRL_CXX_NAMESPACE::ClArgument;
         using cl_context_t          = SIXTRL_CXX_NAMESPACE::ClContext;
@@ -208,7 +210,8 @@ namespace SIXTRL_CXX_NAMESPACE
             size_type const line_begin_idx, size_type const line_end_idx,
             bool const finish_turn ) override;
 
-        SIXTRL_HOST_FN virtual void doCollect() override;
+        SIXTRL_HOST_FN virtual void doCollect(
+            collect_flag_t const flags ) override;
 
         SIXTRL_HOST_FN virtual void doParseConfigStr(
             const char *const SIXTRL_RESTRICT config_str ) override;
@@ -281,6 +284,9 @@ namespace SIXTRL_CXX_NAMESPACE
 
     SIXTRL_HOST_FN void collect(
         TrackJobCl& SIXTRL_RESTRICT_REF track_job ) SIXTRL_NOEXCEPT;
+
+    SIXTRL_HOST_FN void collect( TrackJobCl& SIXTRL_RESTRICT_REF track_job,
+        track_job_collect_flag_t const flags ) SIXTRL_NOEXCEPT;
 
     SIXTRL_HOST_FN TrackJobCl::track_status_t track(
         TrackJobCl& SIXTRL_RESTRICT_REF job,
@@ -396,6 +402,10 @@ NS(TrackJobCl_track_line)(
 
 SIXTRL_EXTERN SIXTRL_HOST_FN void NS(TrackJobCl_collect)(
     NS(TrackJobCl)* SIXTRL_RESTRICT track_job );
+
+SIXTRL_EXTERN SIXTRL_HOST_FN void NS(TrackJobCl_collect_detailed)(
+    NS(TrackJobCl)* SIXTRL_RESTRICT track_job,
+    NS(track_job_collect_flag_t) const flags );
 
 SIXTRL_EXTERN SIXTRL_HOST_FN NS(ClContext)*
 NS(TrackJobCl_get_context)( NS(TrackJobCl)* SIXTRL_RESTRICT track_job );

--- a/tests/python/test_argument_cuda.py
+++ b/tests/python/test_argument_cuda.py
@@ -3,36 +3,35 @@
 
 import sys
 import os
-from   cobjects import CBuffer
+from cobjects import CBuffer
 import pysixtracklib as pyst
-from   pysixtracklib import stcommon as st
+from pysixtracklib import stcommon as st
 import pysixtracklib_test as testlib
 import ctypes as ct
 
 if __name__ == '__main__':
-    num_particles = ct.c_uint64( 100 )
-    pbuffer = st.st_Buffer_new( ct.c_uint64( 0 ) )
-    assert( pbuffer != st.st_NullBuffer )
+    num_particles = ct.c_uint64(100)
+    pbuffer = st.st_Buffer_new(ct.c_uint64(0))
+    assert(pbuffer != st.st_NullBuffer)
 
-    particles = st.st_Particles_new( pbuffer, num_particles )
-    assert( particles != st.st_NullParticles )
+    particles = st.st_Particles_new(pbuffer, num_particles)
+    assert(particles != st.st_NullParticles)
 
     ptr_context = st.st_CudaContext_create()
-    assert( ptr_context != st.st_NullCudaContext )
+    assert(ptr_context != st.st_NullCudaContext)
 
-    particles_arg = st.st_CudaArgument_new( ptr_context )
-    assert( particles_arg != st.st_NullCudaArgument )
+    particles_arg = st.st_CudaArgument_new(ptr_context)
+    assert(particles_arg != st.st_NullCudaArgument)
 
-    success = st.st_CudaArgument_send_buffer( particles_arg, pbuffer )
-    assert( success is True )
+    success = st.st_CudaArgument_send_buffer(particles_arg, pbuffer)
+    assert(success is True)
 
-    success = st.st_CudaArgument_receive_buffer( particles_arg, pbuffer )
-    assert( success is True )
+    success = st.st_CudaArgument_receive_buffer(particles_arg, pbuffer)
+    assert(success is True)
 
-    st.st_CudaArgument_delete( particles_arg )
-    st.st_CudaContext_delete( ptr_context )
-    st.st_Buffer_delete( pbuffer )
+    st.st_CudaArgument_delete(particles_arg)
+    st.st_CudaContext_delete(ptr_context)
+    st.st_Buffer_delete(pbuffer)
     particles = st.st_NullParticles
 
-    sys.exit( 0 )
-
+    sys.exit(0)

--- a/tests/python/test_context_cuda.py
+++ b/tests/python/test_context_cuda.py
@@ -4,14 +4,14 @@
 import sys
 import os
 import pysixtracklib as pyst
-from   pysixtracklib import stcommon as st
+from pysixtracklib import stcommon as st
 import pysixtracklib_test as testlib
 
-if __name__== '__main__':
+if __name__ == '__main__':
     ptr_context = st.st_CudaContext_create()
-    assert( ptr_context != st.st_NullCudaContext )
+    assert(ptr_context != st.st_NullCudaContext)
 
-    st.st_CudaContext_delete( ptr_context )
+    st.st_CudaContext_delete(ptr_context)
     ptr_context = st.st_NullCudaContext
 
 #end: sixtracklib/tests/python/test_context_cuda.py

--- a/tests/python/test_track_job_cpu.py
+++ b/tests/python/test_track_job_cpu.py
@@ -13,8 +13,9 @@ from pysixtracklib.stcommon import \
     st_OutputBuffer_create_output_cbuffer, \
     st_BeamMonitor_assign_output_cbuffer, \
     st_Track_all_particles_element_by_element_until_turn, \
+    st_Particles_buffer_get_particles, \
     st_BeamMonitor_assign_output_buffer, st_Buffer_new_mapped_on_cbuffer, \
-    st_Particles_cbuffer_get_particles
+    st_Particles_cbuffer_get_particles, st_NullBuffer
 
 from pysixtracklib_test.stcommon import st_Particles_print_out, \
     st_Particles_compare_values_with_treshold,\
@@ -94,7 +95,7 @@ if __name__ == '__main__':
     assert(status == 0)
 
     st_Buffer_delete(ptr_belem_buffer)
-    ptr_belem_buffer = pyst.stcommon.st_NullBuffer
+    ptr_belem_buffer = st_NullBuffer
 
     # -------------------------------------------------------------------------
 
@@ -134,5 +135,57 @@ if __name__ == '__main__':
         particles = output_buffer.get_object(ii, pyst.Particles)
         assert(0 == pyst.particles.compareParticlesDifference(
             cmp_particles, particles, abs_treshold=ABS_DIFF))
+
+    del job
+    del track_pb
+    del cmp_track_pb
+    del particles
+    del cmp_particles
+
+    # -------------------------------------------------------------------------
+    # track line:
+
+    track_pb = CBuffer()
+    track_particles = pyst.makeCopy(initial_particles, cbuffer=track_pb)
+
+    cmp_pb = CBuffer()
+    cmp_particles = pyst.makeCopy(initial_particles, cbuffer=cmp_pb)
+    cmp_pbuffer = st_Buffer_new_mapped_on_cbuffer(cmp_pb)
+    assert(cmp_pbuffer != st_NullBuffer)
+
+    lattice = st_Buffer_new_mapped_on_cbuffer(eb)
+    assert(lattice != st_NullBuffer)
+
+    until_turn = 10
+
+    st_Track_all_particles_until_turn(st_Particles_buffer_get_particles(
+        cmp_pbuffer, 0), lattice, ct.c_int64(until_turn))
+
+    st_Buffer_delete(lattice)
+    lattice = st_NullBuffer
+
+    job = pyst.TrackJob(eb, track_pb)
+
+    num_beam_elements = eb.n_objects
+    num_lattice_parts = 10
+    num_elem_per_part = num_beam_elements // num_lattice_parts
+
+    for ii in range(until_turn):
+        for jj in range(num_lattice_parts):
+            is_last_in_turn = bool(jj == (num_lattice_parts - 1))
+            begin_idx = jj * num_elem_per_part
+            end_idx = (not is_last_in_turn) \
+                and begin_idx + num_elem_per_part \
+                or num_beam_elements
+
+            status = job.track_line(begin_idx, end_idx, is_last_in_turn)
+
+    job.collect()
+
+    particles_buffer = job.particles_buffer
+    track_particles = particles_buffer.get_object(0, cls=pyst.Particles)
+
+    assert(0 == pyst.particles.compareParticlesDifference(
+        cmp_particles, track_particles, abs_treshold=ABS_DIFF))
 
     sys.exit(0)

--- a/tests/python/test_track_line_cuda.py
+++ b/tests/python/test_track_line_cuda.py
@@ -4,13 +4,13 @@
 import sys
 import os
 import pysixtracklib as pyst
-from   pysixtracklib import stcommon as st
+from pysixtracklib import stcommon as st
 import pysixtracklib_test as testlib
 import ctypes as ct
-from   cobjects import CBuffer
+from cobjects import CBuffer
 import pdb
 
-if __name__== '__main__':
+if __name__ == '__main__':
     path_to_testdir = testlib.config.PATH_TO_TESTDATA_DIR
     assert(path_to_testdir is not None)
     assert(os.path.exists(path_to_testdir))
@@ -25,96 +25,94 @@ if __name__== '__main__':
     assert(os.path.exists(path_to_beam_elements_data))
 
     pb = CBuffer.fromfile(path_to_particle_data)
-    initial_particles = pb.get_object( 0, cls=pyst.Particles )
+    initial_particles = pb.get_object(0, cls=pyst.Particles)
 
-    track_pb  = CBuffer()
-    particles = pyst.makeCopy( initial_particles, cbuffer=track_pb )
+    track_pb = CBuffer()
+    particles = pyst.makeCopy(initial_particles, cbuffer=track_pb)
 
     eb = CBuffer.fromfile(path_to_beam_elements_data)
     num_beam_elements = eb.n_objects
 
-
     ctx = st.st_CudaContext_create()
-    assert( ctx != st.st_NullCudaContext )
+    assert(ctx != st.st_NullCudaContext)
 
-    lattice = st.st_Buffer_new_mapped_on_cbuffer( eb )
-    assert( lattice != st.st_NullBuffer )
+    lattice = st.st_Buffer_new_mapped_on_cbuffer(eb)
+    assert(lattice != st.st_NullBuffer)
 
+    lattice_arg = st.st_CudaArgument_new(ctx)
+    assert(lattice_arg != st.st_NullCudaArgument)
 
-    lattice_arg = st.st_CudaArgument_new( ctx )
-    assert( lattice_arg != st.st_NullCudaArgument )
+    success = st.st_CudaArgument_send_buffer(lattice_arg, lattice)
+    assert(success)
+    assert(st.st_CudaArgument_uses_cobjects_buffer(lattice_arg))
+    assert(not st.st_CudaArgument_uses_raw_argument(lattice_arg))
+    assert(st.st_CudaArgument_get_size(lattice_arg) ==
+           st.st_Buffer_get_size(lattice))
+    assert(st.st_CudaArgument_get_capacity(lattice_arg) ==
+           st.st_Buffer_get_capacity(lattice))
+    assert(st.st_CudaArgument_has_argument_buffer(lattice_arg))
+    assert(st.st_CudaArgument_requires_argument_buffer(lattice_arg))
 
-    success = st.st_CudaArgument_send_buffer( lattice_arg, lattice )
-    assert( success )
-    assert(  st.st_CudaArgument_uses_cobjects_buffer( lattice_arg ) )
-    assert( not st.st_CudaArgument_uses_raw_argument( lattice_arg ) )
-    assert(  st.st_CudaArgument_get_size( lattice_arg ) ==
-             st.st_Buffer_get_size( lattice ) )
-    assert(  st.st_CudaArgument_get_capacity( lattice_arg ) ==
-             st.st_Buffer_get_capacity( lattice ) )
-    assert(  st.st_CudaArgument_has_argument_buffer( lattice_arg ) )
-    assert(  st.st_CudaArgument_requires_argument_buffer( lattice_arg ) )
+    success = st.st_CudaArgument_receive_buffer(lattice_arg, lattice)
+    assert(success)
 
-    success = st.st_CudaArgument_receive_buffer( lattice_arg, lattice )
-    assert( success )
+    pbuffer = st.st_Buffer_new_mapped_on_cbuffer(track_pb)
+    assert(pbuffer != st.st_NullBuffer)
 
-    pbuffer = st.st_Buffer_new_mapped_on_cbuffer( track_pb )
-    assert( pbuffer != st.st_NullBuffer )
+    particles_arg = st.st_CudaArgument_new(ctx)
+    assert(particles_arg != st.st_NullCudaArgument)
 
-    particles_arg = st.st_CudaArgument_new( ctx )
-    assert( particles_arg != st.st_NullCudaArgument )
+    success = st.st_CudaArgument_send_buffer(particles_arg, pbuffer)
+    assert(success)
 
-    success = st.st_CudaArgument_send_buffer( particles_arg, pbuffer )
-    assert( success )
+    success = st.st_CudaArgument_receive_buffer(particles_arg, pbuffer)
+    assert(success)
 
-    success = st.st_CudaArgument_receive_buffer( particles_arg, pbuffer )
-    assert( success )
+    line_begin = ct.c_uint64(0)
+    line_middle = ct.c_uint64(num_beam_elements // 2)
+    line_end = ct.c_uint64(num_beam_elements)
 
-    line_begin  = ct.c_uint64( 0 )
-    line_middle = ct.c_uint64( num_beam_elements // 2 )
-    line_end    = ct.c_uint64( num_beam_elements )
-
-    num_blocks = ct.c_uint64( 32 )
-    threads_per_block = ct.c_uint64( 32 )
-
-    st.st_Track_particles_line_cuda_on_grid(
-        st.st_CudaArgument_get_arg_buffer( particles_arg ),
-        st.st_CudaArgument_get_arg_buffer( lattice_arg ),
-        line_begin, line_middle, ct.c_bool( False ),
-            num_blocks, threads_per_block )
-
-    success = st.st_CudaArgument_receive_buffer( particles_arg, pbuffer )
-    assert( success )
+    num_blocks = ct.c_uint64(32)
+    threads_per_block = ct.c_uint64(32)
 
     st.st_Track_particles_line_cuda_on_grid(
-        st.st_CudaArgument_get_arg_buffer( particles_arg ),
-        st.st_CudaArgument_get_arg_buffer( lattice_arg ),
-        line_middle, line_end, ct.c_bool( True ),
-        num_blocks, threads_per_block )
+        st.st_CudaArgument_get_arg_buffer(particles_arg),
+        st.st_CudaArgument_get_arg_buffer(lattice_arg),
+        line_begin, line_middle, ct.c_bool(False),
+        num_blocks, threads_per_block)
 
-    success = st.st_CudaArgument_receive_buffer( particles_arg, pbuffer )
-    assert( success )
+    success = st.st_CudaArgument_receive_buffer(particles_arg, pbuffer)
+    assert(success)
+
+    st.st_Track_particles_line_cuda_on_grid(
+        st.st_CudaArgument_get_arg_buffer(particles_arg),
+        st.st_CudaArgument_get_arg_buffer(lattice_arg),
+        line_middle, line_end, ct.c_bool(True),
+        num_blocks, threads_per_block)
+
+    success = st.st_CudaArgument_receive_buffer(particles_arg, pbuffer)
+    assert(success)
 
     cmp_pb = CBuffer()
-    cmp_particles = pyst.makeCopy( initial_particles, cbuffer=cmp_pb )
-    cmp_pbuffer = st.st_Buffer_new_mapped_on_cbuffer( cmp_pb )
-    assert( cmp_pbuffer != st.st_NullBuffer )
+    cmp_particles = pyst.makeCopy(initial_particles, cbuffer=cmp_pb)
+    cmp_pbuffer = st.st_Buffer_new_mapped_on_cbuffer(cmp_pb)
+    assert(cmp_pbuffer != st.st_NullBuffer)
 
     st.st_Track_all_particles_until_turn(
-        st.st_Particles_buffer_get_particles( cmp_pbuffer, 0 ),
-            lattice, ct.c_int64( 1 ) )
+        st.st_Particles_buffer_get_particles(cmp_pbuffer, 0),
+        lattice, ct.c_int64(1))
 
-    assert( pyst.compareParticlesDifference(
-            track_pb.get_object( 0, cls=pyst.Particles ),
-            cmp_pb.get_object( 0, cls=pyst.Particles ),
-            abs_treshold=2e-14 ) == 0 )
+    assert(pyst.compareParticlesDifference(
+        track_pb.get_object(0, cls=pyst.Particles),
+        cmp_pb.get_object(0, cls=pyst.Particles),
+        abs_treshold=2e-14) == 0)
 
-    st.st_CudaArgument_delete( particles_arg )
-    st.st_CudaArgument_delete( lattice_arg )
-    st.st_CudaContext_delete( ctx )
+    st.st_CudaArgument_delete(particles_arg)
+    st.st_CudaArgument_delete(lattice_arg)
+    st.st_CudaContext_delete(ctx)
 
-    st.st_Buffer_delete( pbuffer )
-    st.st_Buffer_delete( lattice )
-    st.st_Buffer_delete( cmp_pbuffer )
+    st.st_Buffer_delete(pbuffer)
+    st.st_Buffer_delete(lattice)
+    st.st_Buffer_delete(cmp_pbuffer)
 
-    sys.exit( 0 )
+    sys.exit(0)


### PR DESCRIPTION
**Summary**
track_line now available also for TrackJobCl (incl. tests), also via Python
Collecting from a TrackJob is now more fine-grained and can be configured
All code compiled without warning
All Unit-test  pass on test-machine
Python requires a reinstallation of pysixtracklib and pysixtracklib_test

**Details:**
- Implement and test the track_line(*) functionality for the OpenCL Track Job as well. this has been tested and confirmed to produce consistent results across all three languages (C99, C++ and Python)

- In order to make track_line work with the current ClContext implementation, some functionality concerning the particle set indices had to be replicated. This is not intended to be a permanent solution and should be replaced when the ClContext is restructured and refactored to meet the design outlined in the CUDA architecture

- TrackJob's gained some API and internal state to select which buffers (particles, beam-elements, output) are fetched when collect() is issued. Additionally, a logical predicate has been created allowing to 
check at run-time whether the TrackJob (positively!) requires a call to collect or not. By virtue of this API, the default is now to only collect the particles and the output buffer (if available) as beam_elements can be collected on demand and/or by enabling the collect operation to also cover them.

_NOTE_: calling collect should always be possible and should not incur any unreasonable run-time costs (i.e. a NOP on the TrackJobCpu). 
_NOTE_: This API is not yet exposed to the Python representation of the TrackJob

- Cosmetic changes to the python files  (i.e. calling autopep8 again)

- Determined that the vast majority of the time spent during the OpenCL unit-tests is contributed by the run-time compilation of kernel programs, especially for AMDPRO orca64 based architectures. Some early benchmarking and performance optimization has been done for the test_track_elem_by_elem_opencl_c99 unit-test

