### PR TITLE
PySixTrackLib: fix mad_helper.dispatch for empty ksl

### DIFF
--- a/python/pysixtracklib/mad_helper.py
+++ b/python/pysixtracklib/mad_helper.py
@@ -18,9 +18,14 @@ def dispatch(el, classes):
 
     key = el.base_type.name
     if key == 'multipole':
+        # workaround for missing ksl
+        try:
+            ksl = el.ksl
+        except AttributeError:
+            ksl = [0] * len(el.knl)
         el = Multipole(
             knl=el.knl,
-            ksl=el.ksl,
+            ksl=ksl,
             hxl=el.knl[0],
             hyl=0,
             length=el.lrad)


### PR DESCRIPTION
When `el` is missing the skew `ksl` key (as can happen for
`makethin` generated sequences within `cpymad`), `mad_helper.dispatch`
does throw a missing key -- now it provides an empty ksl
of length knl.