### PR TITLE
mad_helper.py: fixing ksl typo introduced in PR #56

### DIFF
--- a/python/pysixtracklib/mad_helper.py
+++ b/python/pysixtracklib/mad_helper.py
@@ -19,7 +19,7 @@ def dispatch(el, classes):
     key = el.base_type.name
     if key == 'multipole':
         knl= el.knl if hasattr(el,'knl') else [0]
-        ksl= el.knl if hasattr(el,'ksl') else [0]
+        ksl= el.ksl if hasattr(el,'ksl') else [0]
         el = Multipole(
             knl=knl,
             ksl=ksl,


### PR DESCRIPTION
multipoles would read in the knl instead of ksl value
for the skew component.

PR #56 