### PR TITLE
fixes #62 and #63

### DIFF
--- a/cmake/SetupOpenCL.cmake
+++ b/cmake/SetupOpenCL.cmake
@@ -66,8 +66,6 @@ if( NOT  SIXTRACKL_CMAKE_SETUP_OPENCL_FINISHED )
                     message( STATUS ${MSG} )
 
                     set( CXX_OPENCL_HEADER ${CONTRIBUTED_CXX_HEADER} )
-                    set(   SIXTRACKL_OPENCL_INCLUDE_DIR
-                          ${SIXTRACKL_OPENCL_INCLUDE_DIR} ${EXT_OCLCXX_DIR})
 
                 elseif( NOT SIXTRACK_REQUIRE_OFFLINE_BUILD )
                     if( NOT SIXTRACKL_USE_LEGACY_CL_HPP )
@@ -81,8 +79,6 @@ if( NOT  SIXTRACKL_CMAKE_SETUP_OPENCL_FINISHED )
                         message( STATUS "${MSG} ${CONTRIBUTED_CXX_HEADER}" )
 
                         set( CXX_OPENCL_HEADER ${CONTRIBUTED_CXX_HEADER} )
-                        set(   SIXTRACKL_OPENCL_INCLUDE_DIR
-                            ${SIXTRACKL_OPENCL_INCLUDE_DIR} ${EXT_OCLCXX_DIR})
                     endif()
                 endif()
             endif()

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -9,6 +9,16 @@ if( SIXTRACKL_INSTALL_EXAMPLES )
 endif()
 
 # ==============================================================================
+# Handle special case if OpenCL headers have been downloaded by cmake: 
+
+if( SIXTRACKL_ENABLE_OPENCL AND CONTRIBUTED_CXX_HEADER AND EXT_OCLCXX_DIR AND 
+    EXISTS ${CONTRIBUTED_CXX_HEADER} )
+    
+    include_directories( ${EXT_OCLCXX_DIR} )
+    
+endif()
+
+# ==============================================================================
 # Add subdirectories for the different bindings
 
 add_subdirectory( c99 )

--- a/examples/c99/CMakeLists.txt
+++ b/examples/c99/CMakeLists.txt
@@ -58,13 +58,6 @@ list( APPEND EXAMPLE_TARGETS track_beambeam_c99 )
 add_executable( track_job_cpu_c99 track_job_cpu.c )
 list( APPEND EXAMPLE_TARGETS track_job_cpu_c99 )
 
-# -----------------------------------------------------------------------------
-# track_job_opencl_c99:
-
-add_executable( track_job_cl_c99 track_job_cl.c )
-list( APPEND EXAMPLE_TARGETS track_job_cl_c99 )
-
-
 if( SIXTRACKL_ENABLE_CUDA )
     # -------------------------------------------------------------------------
     # track_lhc_no_bb_cuda_c99:
@@ -74,7 +67,14 @@ if( SIXTRACKL_ENABLE_CUDA )
 endif()
 
 if( SIXTRACKL_ENABLE_OPENCL )
-    # -----------------------------------------------------------------------------
+    # --------------------------------------------------------------------------
+    # track_job_opencl_c99:
+
+    add_executable( track_job_cl_c99 track_job_cl.c )
+    list( APPEND EXAMPLE_TARGETS track_job_cl_c99 )
+
+
+    # --------------------------------------------------------------------------
     # run_opencl_kernel:
 
     add_executable( run_opencl_kernel_c99 run_opencl_kernel.c )

--- a/examples/cxx/CMakeLists.txt
+++ b/examples/cxx/CMakeLists.txt
@@ -23,12 +23,6 @@ add_executable( track_job_cpu_cxx track_job_cpu.cpp )
 list( APPEND EXAMPLE_TARGETS track_job_cpu_cxx )
 
 # -----------------------------------------------------------------------------
-# track_job_cpu_cxx:
-
-add_executable( track_job_cl_cxx track_job_cl.cpp )
-list( APPEND EXAMPLE_TARGETS track_job_cl_cxx )
-
-# -----------------------------------------------------------------------------
 # track_lhc_no_bb_cxx:
 
 add_executable( track_lhc_no_bb_cxx track_lhc_no_bb.cpp )
@@ -37,6 +31,12 @@ list( APPEND EXAMPLE_TARGETS track_lhc_no_bb_cxx )
 
 
 if( SIXTRACKL_ENABLE_OPENCL )
+    # -------------------------------------------------------------------------
+    # track_job_cpu_cxx:
+
+    add_executable( track_job_cl_cxx track_job_cl.cpp )
+    list( APPEND EXAMPLE_TARGETS track_job_cl_cxx )
+
     # -------------------------------------------------------------------------
     # run_opencl_kernel_cxx:
     add_executable( run_opencl_kernel_cxx run_opencl_kernel.cpp )

--- a/sixtracklib/common/internal/track_job.cpp
+++ b/sixtracklib/common/internal/track_job.cpp
@@ -28,7 +28,7 @@
     #if defined( SIXTRACKLIB_ENABLE_MODULE_OPENCL ) && \
         ( SIXTRACKLIB_ENABLE_MODULE_OPENCL == 1 )
 
-    #include "sixtracklib/opencl/track_job_cl.h"
+    #include "sixtracklib/opencl/make_track_job.h"
 
     #endif /* OPENCL */
 
@@ -51,17 +51,16 @@ namespace SIXTRL_CXX_NAMESPACE
         {
             #if defined( SIXTRACKLIB_ENABLE_MODULE_OPENCL ) && \
                 ( SIXTRACKLIB_ENABLE_MODULE_OPENCL == 1 )
-            if( 0 == sanitized_str.compare( TRACK_JOB_CL_STR ) )
+            if( 0 == sanitized_str.compare( SIXTRL_TRACK_JOB_CL_STR ) )
             {
-                using track_job_t = SIXTRL_CXX_NAMESPACE::TrackJobCl;
-
                 std::string const device_id_str =
                     TrackJob_extract_device_id_str( config_str );
 
                 char const* device_id_cstr = ( !device_id_str.empty() )
                     ? device_id_str.c_str() : nullptr;
 
-                ptr_job = new track_job_t( device_id_cstr, config_str );
+                ptr_job = SIXTRL_CXX_NAMESPACE::TrackJobCl_create(
+                    device_id_cstr, config_str );
             }
             else
             #endif /* OpenCL 1.x */
@@ -121,7 +120,7 @@ namespace SIXTRL_CXX_NAMESPACE
         {
             #if defined( SIXTRACKLIB_ENABLE_MODULE_OPENCL ) && \
                 ( SIXTRACKLIB_ENABLE_MODULE_OPENCL == 1 )
-            if( sanitized_str.compare( TRACK_JOB_CL_STR ) == 0 )
+            if( sanitized_str.compare( SIXTRL_TRACK_JOB_CL_STR ) == 0 )
             {
                 std::string const device_id_str =
                     TrackJob_extract_device_id_str( config_str );
@@ -129,9 +128,10 @@ namespace SIXTRL_CXX_NAMESPACE
                 char const* device_id_cstr = ( !device_id_str.empty() )
                     ? device_id_str.c_str() : nullptr;
 
-                ptr_job = new TrackJobCl( device_id_cstr, particles_buffer,
-                    num_particle_sets, pset_indices_begin, belemements_buffer,
-                        output_buffer, dump_elem_by_elem_turns, config_str );
+                ptr_job = SIXTRL_CXX_NAMESPACE::TrackJobCl_create( 
+                    device_id_cstr, particles_buffer, num_particle_sets, 
+                        pset_indices_begin, belemements_buffer, output_buffer, 
+                            dump_elem_by_elem_turns, config_str );
             }
             else
             #endif /* OpenCL 1.x */
@@ -160,12 +160,13 @@ namespace SIXTRL_CXX_NAMESPACE
         {
             #if defined( SIXTRACKLIB_ENABLE_MODULE_OPENCL ) && \
                 ( SIXTRACKLIB_ENABLE_MODULE_OPENCL == 1 )
-            if( sanitized_str.compare( TRACK_JOB_CL_STR ) == 0 )
+            if( sanitized_str.compare( SIXTRL_TRACK_JOB_CL_STR ) == 0 )
             {
                 std::string const device_id_str =
                     TrackJob_extract_device_id_str( config_str.c_str() );
 
-                ptr_job = new TrackJobCl( device_id_str, config_str );
+                ptr_job = SIXTRL_CXX_NAMESPACE::TrackJobCl_create( 
+                    device_id_str.c_str(), config_str.c_str() );
             }
             else
             #endif /* OpenCL 1.x */
@@ -236,15 +237,15 @@ namespace SIXTRL_CXX_NAMESPACE
         {
             #if defined( SIXTRACKLIB_ENABLE_MODULE_OPENCL ) && \
                 ( SIXTRACKLIB_ENABLE_MODULE_OPENCL == 1 )
-            if( sanitized_str.compare( TRACK_JOB_CL_STR ) == 0 )
+            if( sanitized_str.compare( SIXTRL_TRACK_JOB_CL_STR ) == 0 )
             {
                 std::string const device_id_str =
                     TrackJob_extract_device_id_str( config_str.c_str() );
 
-                ptr_job = new TrackJobCl( device_id_str, particles_buffer,
-                    particle_set_indices_begin, particle_set_indices_end,
-                        beam_elemements_buffer, output_buffer,
-                            dump_elem_by_elem_turns, config_str );
+                ptr_job = SIXTRL_CXX_NAMESPACE::TrackJobCl_create( 
+                    device_id_str, particles_buffer, num_particle_sets, 
+                        particle_set_indices_begin, beam_elemements_buffer, 
+                            output_buffer, dump_elem_by_elem_turns, config_str );
             }
             else
             #endif /* OpenCL 1.x */

--- a/sixtracklib/opencl/CMakeLists.txt
+++ b/sixtracklib/opencl/CMakeLists.txt
@@ -76,6 +76,7 @@ set( SIXTRACKLIB_OPENCL_HEADERS
      argument.h
      context.h
      track_job_cl.h
+     make_track_job.h
 )
 
 set( SIXTRACKLIB_OPENCL_INTERNAL_HEADERS
@@ -88,6 +89,7 @@ set( SIXTRACKLIB_OPENCL_SOURCES
      internal/base_context.cpp
      internal/context.cpp
      internal/track_job_cl.cpp
+     internal/make_track_job.cpp
 )
 
 set( SIXTRACKLIB_OPENCL_C99_HEADERS
@@ -113,8 +115,9 @@ add_library( sixtrack_opencl OBJECT
 )
 
 target_include_directories( sixtrack_opencl PUBLIC
-    ${CMAKE_SOURCE_DIR}
-    ${SIXTRACKL_OPENCL_INCLUDE_DIR} )
+    $<BUILD_INTERFACE:${CMAKE_SOURCE_DIR}>
+    $<BUILD_INTERFACE:${SIXTRACKL_OPENCL_INCLUDE_DIR}>
+)
 
 set_target_properties( sixtrack_opencl PROPERTIES LINKER_LANGUAGE C )
 set_target_properties( sixtrack_opencl PROPERTIES POSITION_INDEPENDENT_CODE True )
@@ -146,6 +149,23 @@ set_target_properties( sixtrack_opencl_c99 PROPERTIES C_STANDARD_REQUIRED ON   )
 
 target_compile_options( sixtrack_opencl_c99 BEFORE PUBLIC
         ${SIXTRACKLIB_CPU_FLAGS} -Wall -Werror -pedantic -ansi )
+        
+        
+# ------------------------------------------------------------------------------
+# Handle special case if OpenCL headers have been downloaded by cmake: 
+
+if( CONTRIBUTED_CXX_HEADER AND EXT_OCLCXX_DIR AND 
+    EXISTS ${CONTRIBUTED_CXX_HEADER} )
+    
+    target_include_directories( sixtrack_opencl PRIVATE
+        $<BUILD_INTERFACE:${EXT_OCLCXX_DIR}>
+    )
+    
+    target_include_directories( sixtrack_opencl_c99 PRIVATE
+        $<BUILD_INTERFACE:${EXT_OCLCXX_DIR}>
+    )
+    
+endif()
 
 # ------------------------------------------------------------------------------
 # pass on sixtrack_opencl as a module for sixtracklib:

--- a/sixtracklib/opencl/cl.h.template
+++ b/sixtracklib/opencl/cl.h.template
@@ -33,7 +33,20 @@
         #define SIXTRL_OPENCL_CXX_ENABLES_HOST_EXCEPTIONS @SIXTRL_OPENCL_ENABLES_EXCEPTION_FLAG@
     #endif /* !defined( SIXTRL_OPENCL_CXX_ENABLES_HOST_EXCEPTIONS ) */
 
+    /* Attempt to disable -Wignored-attributes warnings on affected compilers
+     * only for the C++ OpenCL header -> cf. 
+     * http://eigen.tuxfamily.org/bz/show_bug.cgi?id=1221 for reference */
+    
+    #if defined( __GNUC__ ) && __GNUC__ >= 6 
+        #pragma GCC diagnostic push
+        #pragma GCC diagnostic ignored "-Wignored-attributes"
+    #endif 
+    
     #include <@SIXTRL_OPENCL_CL_HPP@>
+    
+    #if defined( __GNUC__ ) && __GNUC__ >= 6
+        #pragma GCC diagnostic pop
+    #endif
 
 #endif /* C++, Host */
 

--- a/sixtracklib/opencl/internal/make_track_job.cpp
+++ b/sixtracklib/opencl/internal/make_track_job.cpp
@@ -1,0 +1,78 @@
+#include "sixtracklib/opencl/make_track_job.h"
+
+#include <cstddef>
+#include <cstdlib>
+#include <memory>
+#include <utility>
+
+#include "sixtracklib/common/definitions.h"
+#include "sixtracklib/common/generated/modules.h"
+#include "sixtracklib/common/internal/track_job_base.h"
+#include "sixtracklib/opencl/track_job_cl.h"
+
+namespace st = SIXTRL_CXX_NAMESPACE;
+
+namespace SIXTRL_CXX_NAMESPACE
+{
+    st::TrackJobBase* TrackJobCl_create( 
+        char const* SIXTRL_RESTRICT device_id_str, 
+        char const* SIXTRL_RESTRICT config_str )
+    {
+        return new st::TrackJobCl( device_id_str, config_str );
+    }
+    
+    st::TrackJobBase* TrackJobCl_create( 
+        std::string const& SIXTRL_RESTRICT_REF device_id_str,
+        Buffer& SIXTRL_RESTRICT_REF particles_buffer,
+        Buffer::size_type const num_particle_sets,
+        Buffer::size_type const* SIXTRL_RESTRICT pset_indices_begin,
+        Buffer& SIXTRL_RESTRICT_REF beam_elemements_buffer,
+        Buffer* SIXTRL_RESTRICT output_buffer,
+        Buffer::size_type const dump_elem_by_elem_turns,
+        std::string const& SIXTRL_RESTRICT_REF config_str )
+    {
+        return new st::TrackJobCl( device_id_str, particles_buffer,
+            pset_indices_begin, pset_indices_begin + num_particle_sets, 
+                beam_elemements_buffer, output_buffer, 
+                    dump_elem_by_elem_turns, config_str );
+    }
+    
+    st::TrackJobBase* TrackJobCl_create( 
+        char const* SIXTRL_RESTRICT device_id_str, 
+        ::NS(Buffer)* SIXTRL_RESTRICT particles_buffer,
+        ::NS(buffer_size_t) const num_particle_sets,
+        ::NS(buffer_size_t) const* SIXTRL_RESTRICT pset_indices_begin,
+        ::NS(Buffer)* SIXTRL_RESTRICT belemements_buffer,
+        ::NS(Buffer)* SIXTRL_RESTRICT output_buffer,
+        ::NS(buffer_size_t) const dump_elem_by_elem_turns,
+        char const* SIXTRL_RESTRICT config_str )
+    {
+        return new st::TrackJobCl( device_id_str, particles_buffer,
+                    num_particle_sets, pset_indices_begin, belemements_buffer,
+                        output_buffer, dump_elem_by_elem_turns, config_str );
+    }
+}
+
+::NS(TrackJobBase)* NS(TrackJobCl_create)(
+    char const* SIXTRL_RESTRICT device_id_str, 
+    char const* SIXTRL_RESTRICT config_str )
+{
+    return new st::TrackJobCl( device_id_str, config_str );
+}
+
+::NS(TrackJobBase)* NS(TrackJobCl_create_detailed)( 
+        char const* SIXTRL_RESTRICT device_id_str, 
+        ::NS(Buffer)* SIXTRL_RESTRICT particles_buffer,
+        ::NS(buffer_size_t) const num_particle_sets,
+        ::NS(buffer_size_t) const* SIXTRL_RESTRICT pset_indices_begin,
+        ::NS(Buffer)* SIXTRL_RESTRICT belemements_buffer,
+        ::NS(Buffer)* SIXTRL_RESTRICT output_buffer,
+        ::NS(buffer_size_t) const dump_elem_by_elem_turns,
+        char const* SIXTRL_RESTRICT config_str )
+{
+    return new st::TrackJobCl( device_id_str, particles_buffer,
+                num_particle_sets, pset_indices_begin, belemements_buffer,
+                    output_buffer, dump_elem_by_elem_turns, config_str );
+}
+
+/* end: sixtracklib/opencl/internal/make_track_job.cpp */

--- a/sixtracklib/opencl/make_track_job.h
+++ b/sixtracklib/opencl/make_track_job.h
@@ -1,0 +1,66 @@
+#ifndef SIXTRL_SIXTRACKLIB_OPENCL_MAKE_TRACK_JOB_H__
+#define SIXTRL_SIXTRACKLIB_OPENCL_MAKE_TRACK_JOB_H__
+
+#if !defined( SIXTRL_TRACK_JOB_CL_ID )
+    #define   SIXTRL_TRACK_JOB_CL_ID 2
+#endif /* !defined( SIXTRL_TRACK_JOB_CL_ID ) */
+
+#if !defined( SIXTRL_TRACK_JOB_CL_STR )
+    #define   SIXTRL_TRACK_JOB_CL_STR "opencl"
+#endif /* !defined( SIXTRL_TRACK_JOB_CL_STR ) */
+
+#if !defined( SIXTRL_NO_INCLUDES )
+    #include "sixtracklib/common/definitions.h"
+    #include "sixtracklib/common/generated/modules.h"
+    #include "sixtracklib/common/buffer.h"
+    #include "sixtracklib/common/internal/track_job_base.h"
+#endif /* !defined( SIXTRL_NO_INCLUDES ) */
+
+#if defined( __cplusplus )
+
+namespace SIXTRL_CXX_NAMESPACE
+{
+    TrackJobBase* TrackJobCl_create( 
+        char const* SIXTRL_RESTRICT device_id_str, 
+        char const* SIXTRL_RESTRICT config_str );
+    
+    TrackJobBase* TrackJobCl_create( 
+        std::string const& SIXTRL_RESTRICT_REF arch_str,
+        Buffer& SIXTRL_RESTRICT_REF particles_buffer,
+        Buffer::size_type const num_particle_sets,
+        Buffer::size_type const* SIXTRL_RESTRICT particle_set_indices_begin,
+        Buffer& SIXTRL_RESTRICT_REF beam_elemements_buffer,
+        Buffer* SIXTRL_RESTRICT output_buffer,
+        Buffer::size_type const dump_elem_by_elem_turns,
+        std::string const& SIXTRL_RESTRICT_REF config_str );
+    
+    TrackJobBase* TrackJobCl_create( 
+        char const* SIXTRL_RESTRICT device_id_str, 
+        ::NS(Buffer)* SIXTRL_RESTRICT particles_buffer,
+        ::NS(buffer_size_t) const num_particle_sets,
+        ::NS(buffer_size_t) const* SIXTRL_RESTRICT pset_indices_begin,
+        ::NS(Buffer)* SIXTRL_RESTRICT belemements_buffer,
+        ::NS(Buffer)* SIXTRL_RESTRICT output_buffer,
+        ::NS(buffer_size_t) const dump_elem_by_elem_turns,
+        char const* SIXTRL_RESTRICT config_str );
+}
+
+NS(TrackJobBase)* NS(TrackJobCl_create)(
+    char const* SIXTRL_RESTRICT device_id_str, 
+    char const* SIXTRL_RESTRICT config_str );
+
+NS(TrackJobBase)* NS(TrackJobCl_create_detailed)(
+    char const* SIXTRL_RESTRICT device_id_str, 
+    ::NS(Buffer)* SIXTRL_RESTRICT particles_buffer,
+    ::NS(buffer_size_t) const num_particle_sets,
+    ::NS(buffer_size_t) const* SIXTRL_RESTRICT pset_indices_begin,
+    ::NS(Buffer)* SIXTRL_RESTRICT belemements_buffer,
+    ::NS(Buffer)* SIXTRL_RESTRICT output_buffer,
+    ::NS(buffer_size_t) const dump_elem_by_elem_turns,
+    char const* SIXTRL_RESTRICT config_str );
+
+#endif /* defined( __cplusplus ) */
+
+#endif /* SIXTRL_SIXTRACKLIB_OPENCL_MAKE_TRACK_JOB_H__ */
+
+/* end: sixtracklib/opencl/make_track_job.h */

--- a/sixtracklib/opencl/track_job_cl.h
+++ b/sixtracklib/opencl/track_job_cl.h
@@ -21,17 +21,10 @@
 
     #include "sixtracklib/opencl/context.h"
     #include "sixtracklib/opencl/argument.h"
+    #include "sixtracklib/opencl/make_track_job.h"
 #endif /* !defined( SIXTRL_NO_INCLUDES ) */
 
 #if !defined( _GPUCODE )
-
-#if !defined( SIXTRL_TRACK_JOB_CL_ID )
-    #define   SIXTRL_TRACK_JOB_CL_ID 2
-#endif /* !defined( SIXTRL_TRACK_JOB_CL_ID ) */
-
-#if !defined( SIXTRL_TRACK_JOB_CL_STR )
-    #define   SIXTRL_TRACK_JOB_CL_STR "opencl"
-#endif /* !defined( SIXTRL_TRACK_JOB_CL_STR ) */
 
 #if defined( __cplusplus )
 

--- a/sixtracklib/sixtracklib.h
+++ b/sixtracklib/sixtracklib.h
@@ -57,14 +57,6 @@
 #include "sixtracklib/common/track_job_cpu.h"
 #include "sixtracklib/common/track.h"
 
-/* - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - */
-
-#if defined( SIXTRACKLIB_ENABLE_MODULE_SIMD ) && \
-           ( SIXTRACKLIB_ENABLE_MODULE_SIMD == 1 )
-
-    #include "sixtracklib/simd/track.h"
-
-#endif /* defined( SIXTRACKLIB_ENABLE_MODULE_SIMD ) */
 
 /* - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - */
 

--- a/tests/sixtracklib/opencl/CMakeLists.txt
+++ b/tests/sixtracklib/opencl/CMakeLists.txt
@@ -1,5 +1,15 @@
 # tests/sixtracklib/opencl/CMakeLists.txt
 
+# ==============================================================================
+# Handle special case if OpenCL headers have been downloaded by cmake: 
+
+if( SIXTRACKL_ENABLE_OPENCL AND CONTRIBUTED_CXX_HEADER AND EXT_OCLCXX_DIR AND 
+    EXISTS ${CONTRIBUTED_CXX_HEADER} )
+    
+    include_directories( ${EXT_OCLCXX_DIR} )
+    
+endif()
+
 if( GTEST_FOUND )
 
     set(   C99_UNIT_TEST_TARGETS )


### PR DESCRIPTION
1) #62 is a known problem and the only known workaround is to disable the specific type of warning in the context of the CL/cl2.hpp file. Cf. for reference also http://eigen.tuxfamily.org/bz/show_bug.cgi?id=1221 

This has been fixed by a gcc specific pragma 

2) Concerning #63, it seems that the mechanism to pass on the include path does not work reliably if the path is within the project source directory. This is especially true for the INSTALL_INTERFACE. An attempt has been made to 
- isolate OpenCL further from other submodules (such as common via the base TrackJobBase API)
- special case the include path at those locations where it is relevant
- mandate an installed OpenCL header for the INSTALL_INTERFACE 

TODO: Find a proper fix for this especially in the install interface case