### PR TITLE
beam_elements, python: using DriftExact by default for from_mad

### DIFF
--- a/python/pysixtracklib/beam_elements.py
+++ b/python/pysixtracklib/beam_elements.py
@@ -255,9 +255,11 @@ class Elements(object):
         return cls(cbuffer=cbuffer)
 
     @classmethod
-    def fromline(cls, line):
+    def fromline(cls, line, exact_drift=False):
         self = cls()
         for label, element_name, element in line:
+            if exact_drift and element_name == 'Drift':
+                element_name = 'DriftExact'
             getattr(self, element_name)(**element._asdict())
         return self
 
@@ -288,15 +290,9 @@ class Elements(object):
         return self.cbuffer.get_object(objid)
 
     @classmethod
-    def from_mad(cls, seq, drift_exact=False):
-        if drift_exact:
-            drift = Elements.element_types['Drift']
-            Elements.element_types['Drift'] = DriftExact
+    def from_mad(cls, seq, exact_drift=False):
         line = madseq_to_line(seq)
-        instance = cls.fromline(line)
-        if drift_exact:
-            Elements.element_types['Drift'] = drift
-        return instance
+        return cls.fromline(line, exact_drift=exact_drift)
 
     # @classmethod
     # def from_mad2(cls, seq):

--- a/python/pysixtracklib/beam_elements.py
+++ b/python/pysixtracklib/beam_elements.py
@@ -288,7 +288,7 @@ class Elements(object):
         return self.cbuffer.get_object(objid)
 
     @classmethod
-    def from_mad(cls, seq, drift_exact=True):
+    def from_mad(cls, seq, drift_exact=False):
         if drift_exact:
             drift = Elements.element_types['Drift']
             Elements.element_types['Drift'] = DriftExact

--- a/python/pysixtracklib/beam_elements.py
+++ b/python/pysixtracklib/beam_elements.py
@@ -288,9 +288,15 @@ class Elements(object):
         return self.cbuffer.get_object(objid)
 
     @classmethod
-    def from_mad(cls, seq):
+    def from_mad(cls, seq, drift_exact=True):
+        if drift_exact:
+            drift = Elements.element_types['Drift']
+            Elements.element_types['Drift'] = DriftExact
         line = madseq_to_line(seq)
-        return cls.fromline(line)
+        instance = cls.fromline(line)
+        if drift_exact:
+            Elements.element_types['Drift'] = drift
+        return instance
 
     # @classmethod
     # def from_mad2(cls, seq):


### PR DESCRIPTION
When converting MAD-X lattices, this patch will allow to use `DriftExact` instead of the truncated `Drift` via a flag.

The default setting is equivalent to what MAD-X does, so it will take `DriftExact` instead of `Drift`, as the MAD-X thin lens tracking also uses the exact drift.

Addresses #71 .