### PR TITLE
Fixes issues in python CudaTrackJob; provides example for pycuda interaction

### DIFF
--- a/examples/python/cuda_particle_addr.py
+++ b/examples/python/cuda_particle_addr.py
@@ -2,13 +2,14 @@
 # -*- coding: utf-8 -*-
 
 import importlib
-
+from importlib import util
 import ctypes as ct
 import pysixtracklib as pyst
 from pysixtracklib import stcommon as st
-import numpy as np
+import pdb
 
-pycuda_spec = importlib.util.find_spec('pycuda')
+pycuda_spec = util.find_spec('pycuda')
+numpy_spec = util.find_spec('numpy')
 
 if pycuda_spec is not None:
     import pycuda
@@ -17,7 +18,7 @@ if pycuda_spec is not None:
     import pycuda.autoinit
 
 if numpy_spec is not None:
-
+    import numpy as np
 
 if __name__ == '__main__':
     if not pyst.supports('cuda'):
@@ -25,6 +26,9 @@ if __name__ == '__main__':
 
     if pycuda_spec is None:
         raise SystemExit("Example requires pycuda installation")
+
+    if numpy_spec is None:
+        raise SystemExit("Example requires numpy installation")
 
     num_particles = 42
     partset = pyst.ParticlesSet()
@@ -37,9 +41,10 @@ if __name__ == '__main__':
     elements.Drift(length=1.2)
     elements.Multipole(knl=[0, 0.001])
 
+    pdb.set_trace()
     track_job = pyst.CudaTrackJob(elements, partset)
 
-    if not track_job.has_particles_addresses and \
+    if not track_job.has_particle_addresses and \
             track_job.can_fetch_particle_addresses:
         track_job.fetch_particle_addresses()
 
@@ -48,13 +53,15 @@ if __name__ == '__main__':
     particles_addr = ptr_particles_addr.contents
 
     print("Particle structure data on the device:")
-    print("num_particles = {0:8d}".format(particles_addr.num_particles))
+    print("num_particles  = {0:8d}".format(particles_addr.num_particles))
     print("x     begin at = {0:16x}".format(particles_addr.x))
     print("y     begin at = {0:16x}".format(particles_addr.y))
     print("px    begin at = {0:16x}".format(particles_addr.px))
     print("py    begin at = {0:16x}".format(particles_addr.py))
     print("zeta  begin at = {0:16x}".format(particles_addr.zeta))
     print("delta begin at = {0:16x}".format(particles_addr.delta))
+
+    pdb.set_trace()
 
     x = pycuda.gpuarray.GPUArray(
         particles_addr.num_particles, float, gpudata=particles_addr.x)

--- a/examples/python/cuda_particle_addr.py
+++ b/examples/python/cuda_particle_addr.py
@@ -48,8 +48,7 @@ if __name__ == '__main__':
             track_job.can_fetch_particle_addresses:
         track_job.fetch_particle_addresses()
 
-    pset_index = 0
-    ptr_particles_addr = track_job.get_particle_addresses(pset_index)
+    ptr_particles_addr = track_job.get_particle_addresses(0)
     particles_addr = ptr_particles_addr.contents
 
     print("Particle structure data on the device:")
@@ -63,19 +62,22 @@ if __name__ == '__main__':
 
     pdb.set_trace()
 
-    x = pycuda.gpuarray.GPUArray(
-        particles_addr.num_particles, float, gpudata=particles_addr.x)
+    cuda_x = pycuda.gpuarray.GPUArray(
+        particles_addr.num_particles, np.float64, gpudata=particles_addr.x)
 
-    x = np.linspace(0.0, float(num_particles - 1), num=num_particles,
-                    dtype=np.float64)
+    new_x_values = np.linspace(
+        0.0, float( num_particles - 1 ), num=num_particles, dtype=np.float64 )
 
-    cmp_particles.x = np.linspace(
-        0.0, float(num_particles - 1), num=num_particles, dtype=np.float64)
+    cuda_x = new_x_values
+
+    for ii in range( 0, num_particles ):
+        cmp_particles.x[ ii ] = float( ii )
 
     assert pyst.compareParticlesDifference(
         cmp_particles, particles, abs_treshold=2e-14) != 0
 
     track_job.collectParticles()
+    assert track_job.last_status_success
 
     assert pyst.compareParticlesDifference(
         cmp_particles, particles, abs_treshold=2e-14) == 0

--- a/examples/python/pycuda_particle_addr.py
+++ b/examples/python/pycuda_particle_addr.py
@@ -41,7 +41,6 @@ if __name__ == '__main__':
     elements.Drift(length=1.2)
     elements.Multipole(knl=[0, 0.001])
 
-    pdb.set_trace()
     track_job = pyst.CudaTrackJob(elements, partset)
 
     if not track_job.has_particle_addresses and \
@@ -60,18 +59,18 @@ if __name__ == '__main__':
     print("zeta  begin at = {0:16x}".format(particles_addr.zeta))
     print("delta begin at = {0:16x}".format(particles_addr.delta))
 
-    pdb.set_trace()
-
     cuda_x = pycuda.gpuarray.GPUArray(
         particles_addr.num_particles, np.float64, gpudata=particles_addr.x)
 
     new_x_values = np.linspace(
         0.0, float( num_particles - 1 ), num=num_particles, dtype=np.float64 )
 
-    cuda_x = new_x_values
+    cuda_x[:] = new_x_values
 
     for ii in range( 0, num_particles ):
         cmp_particles.x[ ii ] = float( ii )
+
+    track_job.fetch_particle_addresses()
 
     assert pyst.compareParticlesDifference(
         cmp_particles, particles, abs_treshold=2e-14) != 0
@@ -81,3 +80,7 @@ if __name__ == '__main__':
 
     assert pyst.compareParticlesDifference(
         cmp_particles, particles, abs_treshold=2e-14) == 0
+
+    del track_job
+    del cuda_x
+

--- a/sixtracklib/cuda/control/controller.cpp
+++ b/sixtracklib/cuda/control/controller.cpp
@@ -360,6 +360,8 @@ namespace SIXTRL_CXX_NAMESPACE
         {
             cudaError_t const err = ::cudaFree( this->m_cuda_debug_register );
             SIXTRL_ASSERT( err == ::cudaSuccess );
+            ( void )err;
+
             this->m_cuda_debug_register = nullptr;
         }
     }


### PR DESCRIPTION
Important: If the pycuda clean-up routines kick in before pysixtracklib elements such as CudaController, CudaArgument, CudaTrackJob are destroyed, the device memory regions will be invalidated. 

In order to avoid this, it is suggested to stick to this sequence:
- first initialize pycuda
- then create any pysixtracklib (i.e. CudaTrackJob, CudaArgument, etc. ) or pycuda elements that you need
- then destroy/delete the pysixtracklib elements before
- destroying the pycuda elements

This is the sequence implemented in the example file examples/python/pycuda_particle_addr.py

Failing to do things properly may result in all kind of problems resulting from accessing already freed memory but will, positively, result in hitting an assert statement in the C++ CudaController destructor if the library has been compiled in debug mode (i.e. with cmake .. -DCMAKE_BUILD_TYPE=Debug). Watch out for the message
```
python: sixtracklib/cuda/control/controller.cpp:374:
virtual sixtrack::CudaController::~CudaController(): Assertion `( err == ::cudaSuccess )' failed.
Aborted (core dumped)
``` 