### PR TITLE
python beam_elements: fixing bug in temporary Element.from_mad

### DIFF
--- a/python/sixtracklib/beam_elements.py
+++ b/python/sixtracklib/beam_elements.py
@@ -436,6 +436,7 @@ class Elements(object):
     @classmethod
     def from_mad(cls, seq, exact_drift=False):
         # temporary
+        self = cls()
         for label, element_name, element in madseq_to_generator(seq):
             if exact_drift and element_name == 'Drift':
                 element_name = 'DriftExact'


### PR DESCRIPTION
In the python library, `sixtracklib.beam_elements.Element.from_mad` now reproduces the same behaviour as it had before the recent changes in commit `c070fb6b9e7a3ae3c08050e92a8751f7103fe0b4` (here `append_line` was integrated into `from_mad` but it misses instantiating the class before appending the elements).