### PR TITLE
cavity in stl: fix for non-unity charge particles (ions).

### DIFF
--- a/sixtracklib/common/be_cavity/track.h
+++ b/sixtracklib/common/be_cavity/track.h
@@ -46,16 +46,17 @@ SIXTRL_INLINE int NS(Track_particle_cavity)(
     real_t const DEG2RAD  = SIXTRL_PI / ( real_t )180.0;
     real_t const K_FACTOR = ( ( real_t )2.0 * SIXTRL_PI ) / SIXTRL_C_LIGHT;
 
-    real_t const   beta0  = NS(Particles_get_beta0_value)( particles, index );
-    real_t const   zeta   = NS(Particles_get_zeta_value)(  particles, index );
-    real_t const   chi    = NS(Particles_get_chi_value)(   particles, index );
-    real_t         rvv    = NS(Particles_get_rvv_value)(   particles, index );
+    real_t const   beta0  = NS(Particles_get_beta0_value)(        particles, index );
+    real_t const   zeta   = NS(Particles_get_zeta_value)(         particles, index );
+    real_t const   q      = NS(Particles_get_q0_value)(           particles, index ) *
+                            NS(Particles_get_charge_ratio_value)( particles, index );
+    real_t         rvv    = NS(Particles_get_rvv_value)(          particles, index );
     real_t const   tau    = zeta / ( beta0 * rvv );
 
     real_t const   phase  = DEG2RAD  * NS(Cavity_get_lag)( cavity ) -
                             K_FACTOR * NS(Cavity_get_frequency)( cavity ) * tau;
 
-    real_t const energy   = chi * sin( phase ) * NS(Cavity_get_voltage)( cavity );
+    real_t const energy   = q * NS(Cavity_get_voltage)( cavity ) * sin( phase );
 
     SIXTRL_ASSERT( NS(Particles_get_state_value)( particles, index ) ==
                    ( NS(particle_index_t) )1 );


### PR DESCRIPTION
For particles with charge != 1 (`q0!=1`), the cavity kick needs to properly take into account the charge -- this is fixed with this patch.

Comparison notebooks to see the effect, observe cell #35 in all of these cases: the tracking is set up such that in the bucket centre the particles should complete one linear synchrotron period (`Qs = 1e-3` and `n_turns = 1024`):

case (1) [reference: proton tracking (which worked before this commit already)](https://github.com/aoeftiger/sixtracklib_pyht_playground/blob/ab4e75393ce5a664ea80e402d1f4260d23fa3c71/fodo_sc/SixTrackLib_Cavity.ipynb): 
![protons-working](https://user-images.githubusercontent.com/6876174/63591759-fa40a500-c5af-11e9-92a7-1195bbcb6ee4.png)

case (2) [buggy ion tracking before this patch](https://github.com/aoeftiger/sixtracklib_pyht_playground/blob/8acced745acc6218e5d906013459d59a178ebc8b/fodo_sc/SixTrackLib_Cavity.ipynb):
![ions-bug](https://user-images.githubusercontent.com/6876174/63591757-f9a80e80-c5af-11e9-8884-cda9cd5fa7cd.png)

case (3) [fixed ion tracking](https://github.com/aoeftiger/sixtracklib_pyht_playground/blob/c891941654cf75e2aa5892cee460b2ca67ff6ffc/fodo_sc/SixTrackLib_Cavity.ipynb):
![ions-working](https://user-images.githubusercontent.com/6876174/63591758-fa40a500-c5af-11e9-824b-285f111545ff.png)



