### PR TITLE
introduce automatic collection of beam_elements for lattice; updateRegion methods

### DIFF
--- a/sixtracklib/common/be_cavity/be_cavity.h
+++ b/sixtracklib/common/be_cavity/be_cavity.h
@@ -273,7 +273,7 @@ SIXTRL_INLINE int NS(Cavity_compare_values)(
         {
             compare_value = +1;
         }
-        else if( NS(Cavity_get_voltage)( lhs ) >
+        else if( NS(Cavity_get_voltage)( lhs ) <
                  NS(Cavity_get_voltage)( rhs ) )
         {
             compare_value = -1;

--- a/sixtracklib/common/control/argument_base.cpp
+++ b/sixtracklib/common/control/argument_base.cpp
@@ -21,10 +21,12 @@ namespace st = SIXTRL_CXX_NAMESPACE;
 
 namespace SIXTRL_CXX_NAMESPACE
 {
-    ArgumentBase::status_t ArgumentBase::send(
-        ArgumentBase::perform_remap_flag_t const perform_remap_flag )
+    using _base_t = st::ArgumentBase;
+
+    _base_t::status_t ArgumentBase::send(
+        _base_t::perform_remap_flag_t const perform_remap_flag )
     {
-        ArgumentBase::status_t success = ArgumentBase::STATUS_GENERAL_FAILURE;
+        _base_t::status_t success = st::ARCH_STATUS_GENERAL_FAILURE;
 
         if( this->usesCObjectsCxxBuffer() )
         {
@@ -44,20 +46,19 @@ namespace SIXTRL_CXX_NAMESPACE
         return success;
     }
 
-    ArgumentBase::status_t ArgumentBase::send(
-        ArgumentBase::buffer_t const& SIXTRL_RESTRICT_REF buffer,
-        ArgumentBase::perform_remap_flag_t const perform_remap_flag )
+    _base_t::status_t ArgumentBase::send(
+        _base_t::buffer_t const& SIXTRL_RESTRICT_REF buffer,
+        _base_t::perform_remap_flag_t const perform_remap_flag )
     {
-        using status_t = ArgumentBase::status_t;
-        using size_t = ArgumentBase::size_type;
-        using ptr_base_controller_t = ArgumentBase::ptr_base_controller_t;
+        using size_t = _base_t::size_type;
+        using ptr_base_controller_t = _base_t::ptr_base_controller_t;
 
-        status_t success = ArgumentBase::STATUS_GENERAL_FAILURE;
+        _base_t::status_t success = st::ARCH_STATUS_GENERAL_FAILURE;
         ptr_base_controller_t ptr_controller = this->ptrControllerBase();
 
         if( ptr_controller != nullptr )
         {
-            success = ArgumentBase::STATUS_SUCCESS;
+            success = st::ARCH_STATUS_SUCCESS;
 
             if( this->usesRawArgument() )
             {
@@ -79,14 +80,14 @@ namespace SIXTRL_CXX_NAMESPACE
 
                     if( !reserved_success )
                     {
-                        success = ArgumentBase::STATUS_GENERAL_FAILURE;
+                        success = st::ARCH_STATUS_GENERAL_FAILURE;
                     }
                 }
 
                 SIXTRL_ASSERT( requ_capacity <= this->capacity() );
             }
 
-            if( ( success == ArgumentBase::STATUS_SUCCESS ) &&
+            if( ( success == st::ARCH_STATUS_SUCCESS ) &&
                 ( ( updated_argument_buffer ) ||
                   ( !this->usesCObjectsCxxBuffer() ) ||
                   ( !this->usesCObjectsBuffer() ) ) )
@@ -94,38 +95,37 @@ namespace SIXTRL_CXX_NAMESPACE
                 this->doSetBufferRef( buffer );
             }
 
-            if( success == ArgumentBase::STATUS_SUCCESS )
+            if( success == st::ARCH_STATUS_SUCCESS )
             {
                 success = ptr_controller->send(
                     this, buffer, perform_remap_flag );
 
-                if( success == ArgumentBase::STATUS_SUCCESS )
+                if( success == st::ARCH_STATUS_SUCCESS )
                 {
                     this->doSetArgSize( buffer.size() );
                 }
             }
 
-            SIXTRL_ASSERT( ( success != ArgumentBase::STATUS_SUCCESS ) ||
+            SIXTRL_ASSERT( ( success != st::ARCH_STATUS_SUCCESS ) ||
                            ( buffer.size() == this->size() ) );
         }
 
         return success;
     }
 
-    ArgumentBase::status_t ArgumentBase::send(
-        const ArgumentBase::c_buffer_t *const SIXTRL_RESTRICT buffer,
-        ArgumentBase::perform_remap_flag_t const perform_remap_flag )
+    _base_t::status_t ArgumentBase::send(
+        const _base_t::c_buffer_t *const SIXTRL_RESTRICT buffer,
+        _base_t::perform_remap_flag_t const perform_remap_flag )
     {
-        using status_t = ArgumentBase::status_t;
-        using size_t = ArgumentBase::size_type;
-        using ptr_base_controller_t = ArgumentBase::ptr_base_controller_t;
+        using size_t = _base_t::size_type;
+        using ptr_base_controller_t = _base_t::ptr_base_controller_t;
 
-        status_t success = ArgumentBase::STATUS_GENERAL_FAILURE;
+        _base_t::status_t success = st::ARCH_STATUS_GENERAL_FAILURE;
         ptr_base_controller_t ptr_controller = this->ptrControllerBase();
 
         if( ptr_controller != nullptr )
         {
-            success = ArgumentBase::STATUS_SUCCESS;
+            success = st::ARCH_STATUS_SUCCESS;
 
             if( this->usesRawArgument() )
             {
@@ -147,48 +147,47 @@ namespace SIXTRL_CXX_NAMESPACE
 
                     if( !reserved_success )
                     {
-                        success = ArgumentBase::STATUS_GENERAL_FAILURE;
+                        success = st::ARCH_STATUS_GENERAL_FAILURE;
                     }
                 }
 
                 SIXTRL_ASSERT( requ_capacity <= this->capacity() );
             }
 
-            if( ( success == ArgumentBase::STATUS_SUCCESS ) &&
+            if( ( success == st::ARCH_STATUS_SUCCESS ) &&
                 ( ( updated_argument_buffer ) ||
                   ( !this->usesCObjectsBuffer() ) ) )
             {
                 this->doSetPtrCBuffer( buffer );
             }
 
-            if( success == ArgumentBase::STATUS_SUCCESS )
+            if( success == st::ARCH_STATUS_SUCCESS )
             {
                 success = ptr_controller->send(
                     this, buffer, perform_remap_flag );
 
-                if( success == ArgumentBase::STATUS_SUCCESS )
+                if( success == st::ARCH_STATUS_SUCCESS )
                 {
                     this->doSetArgSize( ::NS(Buffer_get_size)( buffer ) );
                 }
             }
 
             SIXTRL_ASSERT(
-                ( success != ArgumentBase::STATUS_SUCCESS ) ||
+                ( success != st::ARCH_STATUS_SUCCESS ) ||
                 ( ::NS(Buffer_get_size)( buffer ) == this->size() ) );
         }
 
         return success;
     }
 
-    ArgumentBase::status_t ArgumentBase::send(
+    _base_t::status_t ArgumentBase::send(
         void const* SIXTRL_RESTRICT raw_arg_begin,
-        ArgumentBase::size_type const raw_arg_len )
+        _base_t::size_type const raw_arg_len )
     {
-        using status_t = ArgumentBase::status_t;
-        using size_t = ArgumentBase::size_type;
-        using ptr_base_controller_t = ArgumentBase::ptr_base_controller_t;
+        using size_t = _base_t::size_type;
+        using ptr_base_controller_t = _base_t::ptr_base_controller_t;
 
-        status_t success = ArgumentBase::STATUS_GENERAL_FAILURE;
+        _base_t::status_t success = st::ARCH_STATUS_GENERAL_FAILURE;
         ptr_base_controller_t ptr_controller = this->ptrControllerBase();
 
         if( ( ptr_controller != nullptr ) && ( raw_arg_begin != nullptr ) &&
@@ -215,22 +214,22 @@ namespace SIXTRL_CXX_NAMESPACE
 
                 if( raw_arg_len <= this->capacity() )
                 {
-                    success = ArgumentBase::STATUS_SUCCESS;
+                    success = st::ARCH_STATUS_SUCCESS;
                 }
             }
             else
             {
-                success = ArgumentBase::STATUS_SUCCESS;
+                success = st::ARCH_STATUS_SUCCESS;
             }
 
-            if( ( success == ArgumentBase::STATUS_SUCCESS ) &&
+            if( ( success == st::ARCH_STATUS_SUCCESS ) &&
                 ( ( updated_argument_buffer ) ||
                   ( !this->usesRawArgument() ) ) )
             {
                 this->doSetPtrRawArgument( raw_arg_begin );
             }
 
-            if( success == ArgumentBase::STATUS_SUCCESS )
+            if( success == st::ARCH_STATUS_SUCCESS )
             {
                 SIXTRL_ASSERT( ( !this->usesCObjectsBuffer() ) &&
                                ( !this->usesCObjectsCxxBuffer() ) );
@@ -238,13 +237,13 @@ namespace SIXTRL_CXX_NAMESPACE
                 success = ptr_controller->send(
                     this, raw_arg_begin, raw_arg_len );
 
-                if( success == ArgumentBase::STATUS_SUCCESS )
+                if( success == st::ARCH_STATUS_SUCCESS )
                 {
                     this->doSetArgSize( raw_arg_len );
                 }
             }
 
-            SIXTRL_ASSERT( ( success != ArgumentBase::STATUS_SUCCESS ) ||
+            SIXTRL_ASSERT( ( success != st::ARCH_STATUS_SUCCESS ) ||
                            ( this->size() == raw_arg_len ) );
 
         }
@@ -252,10 +251,10 @@ namespace SIXTRL_CXX_NAMESPACE
         return success;
     }
 
-    ArgumentBase::status_t ArgumentBase::receive(
-        ArgumentBase::perform_remap_flag_t const perform_remap_flag )
+    _base_t::status_t ArgumentBase::receive(
+        _base_t::perform_remap_flag_t const perform_remap_flag )
     {
-        ArgumentBase::status_t success = ArgumentBase::STATUS_GENERAL_FAILURE;
+        _base_t::status_t success = st::ARCH_STATUS_GENERAL_FAILURE;
 
         if( this->usesCObjectsCxxBuffer() )
         {
@@ -275,15 +274,12 @@ namespace SIXTRL_CXX_NAMESPACE
         return success;
     }
 
-    ArgumentBase::status_t ArgumentBase::receive(
-        ArgumentBase::buffer_t& SIXTRL_RESTRICT_REF buffer,
-        ArgumentBase::perform_remap_flag_t const perform_remap_flag )
+    _base_t::status_t ArgumentBase::receive(
+        _base_t::buffer_t& SIXTRL_RESTRICT_REF buffer,
+        _base_t::perform_remap_flag_t const perform_remap_flag )
     {
-
-        using status_t = ArgumentBase::status_t;
-        using ptr_base_controller_t = ArgumentBase::ptr_base_controller_t;
-
-        status_t success = ArgumentBase::STATUS_GENERAL_FAILURE;
+        using ptr_base_controller_t = _base_t::ptr_base_controller_t;
+        _base_t::status_t success = st::ARCH_STATUS_GENERAL_FAILURE;
         ptr_base_controller_t ptr_controller = this->ptrControllerBase();
 
         if( ( ptr_controller != nullptr ) && ( this->usesCObjectsBuffer() ) )
@@ -295,15 +291,12 @@ namespace SIXTRL_CXX_NAMESPACE
         return success;
     }
 
-    ArgumentBase::status_t ArgumentBase::receive(
-        ArgumentBase::c_buffer_t* SIXTRL_RESTRICT buf,
-        ArgumentBase::perform_remap_flag_t const perform_remap_flag )
+    _base_t::status_t ArgumentBase::receive(
+        _base_t::c_buffer_t* SIXTRL_RESTRICT buf,
+        _base_t::perform_remap_flag_t const perform_remap_flag )
     {
-
-        using status_t = ArgumentBase::status_t;
-        using ptr_base_controller_t = ArgumentBase::ptr_base_controller_t;
-
-        status_t success = ArgumentBase::STATUS_GENERAL_FAILURE;
+        using ptr_base_controller_t = _base_t::ptr_base_controller_t;
+        _base_t::status_t success = st::ARCH_STATUS_GENERAL_FAILURE;
         ptr_base_controller_t ptr_controller = this->ptrControllerBase();
 
         if( ( ptr_controller != nullptr ) && ( this->usesCObjectsBuffer() ) )
@@ -314,14 +307,12 @@ namespace SIXTRL_CXX_NAMESPACE
         return success;
     }
 
-    ArgumentBase::status_t ArgumentBase::receive(
+    _base_t::status_t ArgumentBase::receive(
         void* SIXTRL_RESTRICT raw_arg_begin,
-        ArgumentBase::size_type const raw_arg_capacity )
+        _base_t::size_type const raw_arg_capacity )
     {
-        using status_t = ArgumentBase::status_t;
-        using ptr_base_controller_t = ArgumentBase::ptr_base_controller_t;
-
-        status_t success = ArgumentBase::STATUS_GENERAL_FAILURE;
+        using ptr_base_controller_t = _base_t::ptr_base_controller_t;
+        _base_t::status_t success = st::ARCH_STATUS_GENERAL_FAILURE;
         ptr_base_controller_t ptr_controller = this->ptrControllerBase();
 
         if( ( ptr_controller != nullptr ) &&
@@ -334,12 +325,10 @@ namespace SIXTRL_CXX_NAMESPACE
         return success;
     }
 
-    ArgumentBase::status_t ArgumentBase::remap()
+    _base_t::status_t ArgumentBase::remap()
     {
-        using status_t = ArgumentBase::status_t;
-        using ptr_base_controller_t = ArgumentBase::ptr_base_controller_t;
-
-        status_t status = ArgumentBase::STATUS_GENERAL_FAILURE;
+        using ptr_base_controller_t = _base_t::ptr_base_controller_t;
+        _base_t::status_t status = st::ARCH_STATUS_GENERAL_FAILURE;
         ptr_base_controller_t ptr_controller = this->ptrControllerBase();
 
         if( ( ptr_controller != nullptr ) &&
@@ -363,13 +352,12 @@ namespace SIXTRL_CXX_NAMESPACE
         return ( this->m_ptr_cobj_cxx_buffer != nullptr );
     }
 
-    ArgumentBase::buffer_t*
-    ArgumentBase::ptrCObjectsCxxBuffer() const SIXTRL_NOEXCEPT
+    _base_t::buffer_t* ArgumentBase::ptrCObjectsCxxBuffer() const SIXTRL_NOEXCEPT
     {
         return this->m_ptr_cobj_cxx_buffer;
     }
 
-    ArgumentBase::buffer_t& ArgumentBase::cobjectsCxxBuffer() const
+    _base_t::buffer_t& ArgumentBase::cobjectsCxxBuffer() const
     {
         if( this->m_ptr_cobj_cxx_buffer == nullptr )
         {
@@ -389,18 +377,16 @@ namespace SIXTRL_CXX_NAMESPACE
         return ( this->m_ptr_cobj_c99_buffer != nullptr );
     }
 
-    ArgumentBase::c_buffer_t*
-    ArgumentBase::ptrCObjectsBuffer() const SIXTRL_NOEXCEPT
+    _base_t::c_buffer_t* ArgumentBase::ptrCObjectsBuffer() const SIXTRL_NOEXCEPT
     {
         return this->m_ptr_cobj_c99_buffer;
     }
 
-    ArgumentBase::size_type
-    ArgumentBase::cobjectsBufferSlotSize() const SIXTRL_NOEXCEPT
+    _base_t::size_type ArgumentBase::cobjectsBufferSlotSize() const SIXTRL_NOEXCEPT
     {
         return ( this->usesCObjectsBuffer() )
             ? ::NS(Buffer_get_slot_size)( this->ptrCObjectsBuffer() )
-            : ArgumentBase::size_type{ 0 };
+            : _base_t::size_type{ 0 };
     }
 
     bool ArgumentBase::usesRawArgument() const SIXTRL_NOEXCEPT
@@ -413,12 +399,12 @@ namespace SIXTRL_CXX_NAMESPACE
         return this->m_ptr_raw_arg_begin;
     }
 
-    ArgumentBase::size_type ArgumentBase::size() const SIXTRL_NOEXCEPT
+    _base_t::size_type ArgumentBase::size() const SIXTRL_NOEXCEPT
     {
         return this->m_arg_size;
     }
 
-    ArgumentBase::size_type ArgumentBase::capacity() const SIXTRL_NOEXCEPT
+    _base_t::size_type ArgumentBase::capacity() const SIXTRL_NOEXCEPT
     {
         return this->m_arg_capacity;
     }
@@ -433,31 +419,31 @@ namespace SIXTRL_CXX_NAMESPACE
         return this->m_needs_arg_buffer;
     }
 
-    ArgumentBase::ptr_base_controller_t
+    _base_t::ptr_base_controller_t
     ArgumentBase::ptrControllerBase() SIXTRL_NOEXCEPT
     {
         return this->m_ptr_base_controller;
     }
 
-    ArgumentBase::ptr_const_base_controller_t
+    _base_t::ptr_const_base_controller_t
     ArgumentBase::ptrControllerBase() const SIXTRL_NOEXCEPT
     {
         return this->m_ptr_base_controller;
     }
 
     ArgumentBase::ArgumentBase(
-        ArgumentBase::arch_id_t const arch_id,
+        _base_t::arch_id_t const arch_id,
         char const* SIXTRL_RESTRICT arch_str,
         char const* SIXTRL_RESTRICT config_str,
         bool const needs_argument_buffer,
-        ArgumentBase::ptr_base_controller_t SIXTRL_RESTRICT controller ) :
+        _base_t::ptr_base_controller_t SIXTRL_RESTRICT controller ) :
         st::ArchBase( arch_id, arch_str, config_str ),
         m_ptr_raw_arg_begin( nullptr ),
         m_ptr_cobj_cxx_buffer( nullptr ),
         m_ptr_cobj_c99_buffer( nullptr ),
         m_ptr_base_controller( controller ),
-        m_arg_size( ArgumentBase::size_type{ 0 } ),
-        m_arg_capacity( ArgumentBase::size_type{ 0 } ),
+        m_arg_size( _base_t::size_type{ 0 } ),
+        m_arg_capacity( _base_t::size_type{ 0 } ),
         m_needs_arg_buffer( needs_argument_buffer ),
         m_has_arg_buffer( false )
     {
@@ -467,37 +453,105 @@ namespace SIXTRL_CXX_NAMESPACE
     /* --------------------------------------------------------------------- */
 
     bool ArgumentBase::doReserveArgumentBuffer(
-        ArgumentBase::size_type const required_arg_buffer_capacity )
+        _base_t::size_type const required_arg_buffer_capacity )
     {
         return ( this->capacity() >= required_arg_buffer_capacity );
+    }
+
+    _base_t::status_t ArgumentBase::doUpdateRegions(
+        _base_t::size_type const num_regions_to_update,
+        _base_t::size_type const* SIXTRL_RESTRICT offsets,
+        _base_t::size_type const* SIXTRL_RESTRICT lengths,
+        void const* SIXTRL_RESTRICT const* SIXTRL_RESTRICT new_values )
+    {
+        using size_t = _base_t::size_type;
+
+        _base_t::status_t status = st::ARCH_STATUS_GENERAL_FAILURE;
+
+        if( ( num_regions_to_update > _base_t::size_type{ 0 } ) &&
+            ( offsets != nullptr ) && ( lengths != nullptr ) &&
+            ( new_values != nullptr ) )
+        {
+            status = st::ARCH_STATUS_SUCCESS;
+            size_t const arg_size = this->m_arg_size;
+
+            size_t ii = size_t{ 0 };
+            for( ; ii < num_regions_to_update ; ++ii )
+            {
+                size_t const offset = offsets[ ii ];
+                size_t const length = lengths[ ii ];
+                void const* SIXTRL_RESTRICT new_value = new_values[ ii ];
+
+                if( ( new_value == nullptr ) || ( length == size_t{ 0 } ) ||
+                    ( ( offset + length ) > arg_size ) )
+                {
+                    status = st::ARCH_STATUS_GENERAL_FAILURE;
+                    break;
+                }
+
+                unsigned char* dest = nullptr;
+
+                if( this->usesCObjectsCxxBuffer() )
+                {
+                    dest = reinterpret_cast< unsigned char* >( static_cast<
+                        uintptr_t >( this->ptrCObjectsCxxBuffer(
+                            )->getDataBeginAddr() ) );
+                }
+                else if( this->usesCObjectsBuffer() )
+                {
+                    dest = reinterpret_cast< unsigned char* >( static_cast<
+                    uintptr_t >( ::NS(Buffer_get_data_begin_addr)(
+                        this->ptrCObjectsBuffer() ) ) );
+
+                }
+                else if( this->usesRawArgument() )
+                {
+                    dest = reinterpret_cast< unsigned char* >(
+                        this->m_ptr_raw_arg_begin );
+                }
+
+                if( dest != nullptr )
+                {
+                    std::advance( dest, offset );
+                    std::memcpy( dest, new_value, length );
+                }
+                else
+                {
+                    status = st::ARCH_STATUS_GENERAL_FAILURE;
+                    break;
+                }
+            }
+        }
+
+        return status;
     }
 
     /* ----------------------------------------------------------------- */
 
     void ArgumentBase::doSetArgSize(
-        ArgumentBase::size_type const arg_size ) SIXTRL_NOEXCEPT
+        _base_t::size_type const arg_size ) SIXTRL_NOEXCEPT
     {
         this->m_arg_size = arg_size;
     }
 
     void ArgumentBase::doSetArgCapacity(
-        ArgumentBase::size_type const arg_capacity ) SIXTRL_NOEXCEPT
+        _base_t::size_type const arg_capacity ) SIXTRL_NOEXCEPT
     {
         this->m_arg_capacity = arg_capacity;
     }
 
     void ArgumentBase::doSetPtrControllerBase(
-        ArgumentBase::ptr_base_controller_t SIXTRL_RESTRICT ctrl
+        _base_t::ptr_base_controller_t SIXTRL_RESTRICT ctrl
     ) SIXTRL_NOEXCEPT
     {
         this->m_ptr_base_controller = ctrl;
     }
 
-    void ArgumentBase::doSetBufferRef( ArgumentBase::buffer_t const&
+    void ArgumentBase::doSetBufferRef( _base_t::buffer_t const&
         SIXTRL_RESTRICT_REF buffer ) SIXTRL_NOEXCEPT
     {
-        using c_buffer_t = ArgumentBase::c_buffer_t;
-        using buffer_t   = ArgumentBase::buffer_t;
+        using c_buffer_t = _base_t::c_buffer_t;
+        using buffer_t   = _base_t::buffer_t;
 
         c_buffer_t* _ptr_cobj_c99_buffer =
             const_cast< c_buffer_t* >( buffer.getCApiPtr() );
@@ -516,10 +570,10 @@ namespace SIXTRL_CXX_NAMESPACE
     }
 
     void ArgumentBase::doSetPtrCBuffer(
-        const ArgumentBase::c_buffer_t *const
+        const _base_t::c_buffer_t *const
         SIXTRL_RESTRICT ptr_c_buffer ) SIXTRL_NOEXCEPT
     {
-        using c_buffer_t = ArgumentBase::c_buffer_t;
+        using c_buffer_t = _base_t::c_buffer_t;
 
         c_buffer_t* non_const_ptr = const_cast< c_buffer_t* >( ptr_c_buffer );
 

--- a/sixtracklib/common/control/argument_base.hpp
+++ b/sixtracklib/common/control/argument_base.hpp
@@ -69,10 +69,10 @@ namespace SIXTRL_CXX_NAMESPACE
             size_type const arg_size );
 
 
-        SIXTRL_HOST_FN status_t receive( 
+        SIXTRL_HOST_FN status_t receive(
             perform_remap_flag_t const perform_remap_flag =
                 SIXTRL_CXX_NAMESPACE::CTRL_PERFORM_REMAP );
-        
+
         SIXTRL_HOST_FN status_t receive(
             buffer_t& SIXTRL_RESTRICT_REF buffer,
             perform_remap_flag_t const perform_remap_flag =
@@ -85,6 +85,16 @@ namespace SIXTRL_CXX_NAMESPACE
 
         SIXTRL_HOST_FN status_t receive( void* SIXTRL_RESTRICT arg_begin,
             size_type const arg_capacity );
+
+        SIXTRL_HOST_FN status_t updateRegion(
+            size_type const offset, size_type const length,
+            void const* SIXTRL_RESTRICT_REF new_value );
+
+        SIXTRL_HOST_FN status_t updateRegions(
+            size_type const num_regions_to_update,
+            size_type const* SIXTRL_RESTRICT offsets,
+            size_type const* SIXTRL_RESTRICT lengths,
+            void const* SIXTRL_RESTRICT const* new_values );
 
         SIXTRL_HOST_FN status_t remap();
 
@@ -140,6 +150,12 @@ namespace SIXTRL_CXX_NAMESPACE
 
         SIXTRL_HOST_FN virtual bool doReserveArgumentBuffer(
             size_type const required_buffer_size );
+
+        SIXTRL_HOST_FN virtual status_t doUpdateRegions(
+            size_type const num_regions_to_update,
+            size_type const* SIXTRL_RESTRICT offsets,
+            size_type const* SIXTRL_RESTRICT lengths,
+            void const* SIXTRL_RESTRICT const* SIXTRL_RESTRICT new_values );
 
         /* ----------------------------------------------------------------- */
 
@@ -220,6 +236,25 @@ typedef void NS(ArgumentBase);
 
 namespace SIXTRL_CXX_NAMESPACE
 {
+    SIXTRL_INLINE ArgumentBase::status_t ArgumentBase::updateRegion(
+        ArgumentBase::size_type const offset,
+        ArgumentBase::size_type const size,
+        void const* SIXTRL_RESTRICT new_value )
+    {
+        return this->doUpdateRegions( ArgumentBase::size_type{ 1 },
+            &offset, &size, &new_value );
+    }
+
+    SIXTRL_INLINE ArgumentBase::status_t ArgumentBase::updateRegions(
+        ArgumentBase::size_type const num_regions_to_update,
+        ArgumentBase::size_type const* SIXTRL_RESTRICT offsets,
+        ArgumentBase::size_type const* SIXTRL_RESTRICT sizes,
+        void const* SIXTRL_RESTRICT const* SIXTRL_RESTRICT new_values )
+    {
+        return this->doUpdateRegions(
+            num_regions_to_update, offsets, sizes, new_values );
+    }
+
     template< class Derived > Derived const* ArgumentBase::asDerivedArgument(
         ArgumentBase::arch_id_t const required_arch_id,
         bool requires_exact_match ) const SIXTRL_NOEXCEPT

--- a/sixtracklib/common/internal/track_job_base.h
+++ b/sixtracklib/common/internal/track_job_base.h
@@ -48,6 +48,7 @@ namespace SIXTRL_CXX_NAMESPACE
         using size_type             = SIXTRL_CXX_NAMESPACE::track_job_size_t;
         using type_t                = SIXTRL_CXX_NAMESPACE::track_job_type_t;
         using track_status_t        = SIXTRL_CXX_NAMESPACE::track_status_t;
+        using status_t              = SIXTRL_CXX_NAMESPACE::arch_status_t;
         using output_buffer_flag_t  = ::NS(output_buffer_flag_t);
 
         using collect_flag_t = SIXTRL_CXX_NAMESPACE::track_job_collect_flag_t;

--- a/sixtracklib/opencl/argument.h
+++ b/sixtracklib/opencl/argument.h
@@ -13,6 +13,7 @@
 
 #if !defined( SIXTRL_NO_INCLUDES )
     #include "sixtracklib/common/definitions.h"
+    #include "sixtracklib/common/control/definitions.h"
 #endif /* !defined( SIXTRL_NO_INCLUDES ) */
 
 #if !defined( _GPUCODE ) && defined( __cplusplus )
@@ -59,6 +60,7 @@ namespace SIXTRL_CXX_NAMESPACE
         using size_type          = std::size_t;
         using cobj_buffer_t      = struct NS(Buffer);
         using cxx_cobj_buffer_t  = SIXTRL_CXX_NAMESPACE::Buffer;
+        using status_t           = SIXTRL_CXX_NAMESPACE::arch_status_t;
 
         explicit ClArgument(
             context_base_t* SIXTRL_RESTRICT ptr_context = nullptr );
@@ -99,6 +101,14 @@ namespace SIXTRL_CXX_NAMESPACE
         bool read(  void* SIXTRL_RESTRICT arg_buffer_begin,
                     size_type const arg_length );
 
+        status_t updateRegion( size_type const offset, size_type length,
+            void const* SIXTRL_RESTRICT new_value );
+
+        status_t updateRegions( size_type const num_regions_to_update,
+            size_type const* SIXTRL_RESTRICT offsets,
+            size_type const* SIXTRL_RESTRICT lengths,
+            void const* SIXTRL_RESTRICT const* SIXTRL_RESTRICT new_values );
+
         bool usesCObjectBuffer() const SIXTRL_NOEXCEPT;
         cobj_buffer_t* ptrCObjectBuffer() const SIXTRL_NOEXCEPT;
 
@@ -117,6 +127,11 @@ namespace SIXTRL_CXX_NAMESPACE
 
         virtual int doReadAndRemapCObjBuffer(
             cobj_buffer_t* SIXTRL_RESTRICT buffer );
+
+        virtual status_t doUpdateRegions( size_type const num_regions_to_update,
+            size_type const* SIXTRL_RESTRICT offsets,
+            size_type const* SIXTRL_RESTRICT lengths,
+            void const* SIXTRL_RESTRICT const* SIXTRL_RESTRICT new_values );
 
         void doSetCObjBuffer(
             cobj_buffer_t* SIXTRL_RESTRICT buffer ) const SIXTRL_NOEXCEPT;
@@ -203,6 +218,18 @@ SIXTRL_HOST_FN bool NS(ClArgument_read)(
 SIXTRL_HOST_FN bool NS(ClArgument_read_memory)(
     NS(ClArgument)* SIXTRL_RESTRICT argument,
     void* arg_buffer_begin, NS(context_size_t) const arg_length );
+
+SIXTRL_HOST_FN NS(arch_status_t) NS(ClArgument_update_region)(
+    NS(ClArgument)* SIXTRL_RESTRICT argument,
+    NS(context_size_t) const offset, NS(context_size_t) const length,
+    void const* SIXTRL_RESTRICT new_value );
+
+SIXTRL_HOST_FN NS(arch_status_t) NS(ClArgument_update_regions)(
+    NS(ClArgument)* SIXTRL_RESTRICT argument,
+    NS(context_size_t) const num_regions_to_update,
+    NS(context_size_t) const* SIXTRL_RESTRICT offset,
+    NS(context_size_t) const* SIXTRL_RESTRICT length,
+    void const* SIXTRL_RESTRICT const* SIXTRL_RESTRICT new_values );
 
 SIXTRL_HOST_FN bool NS(ClArgument_uses_cobj_buffer)(
     const NS(ClArgument) *const SIXTRL_RESTRICT argument );

--- a/sixtracklib/opencl/internal/track_job_cl.cpp
+++ b/sixtracklib/opencl/internal/track_job_cl.cpp
@@ -302,6 +302,28 @@ namespace SIXTRL_CXX_NAMESPACE
         return this->m_ptr_cl_elem_by_elem_config_buffer.get();
     }
 
+    TrackJobCl::status_t TrackJobCl::updateBeamElementsRegion(
+        TrackJobCl::size_type const offset, TrackJobCl::size_type const length,
+        void const* SIXTRL_RESTRICT new_value )
+    {
+        return ( this->m_ptr_beam_elements_buffer_arg != nullptr )
+            ? this->m_ptr_beam_elements_buffer_arg->updateRegion(
+                offset, length, new_value )
+            : ::NS(ARCH_STATUS_GENERAL_FAILURE);
+    }
+
+    TrackJobCl::status_t TrackJobCl::updateBeamElementsRegions(
+        TrackJobCl::size_type const num_regions_to_update,
+        TrackJobCl::size_type const* SIXTRL_RESTRICT offsets,
+        TrackJobCl::size_type const* SIXTRL_RESTRICT lengths,
+        void const* SIXTRL_RESTRICT const* SIXTRL_RESTRICT new_values )
+    {
+        return ( this->m_ptr_beam_elements_buffer_arg != nullptr )
+            ? this->m_ptr_beam_elements_buffer_arg->updateRegions(
+                num_regions_to_update, offsets, lengths, new_values )
+            : ::NS(ARCH_STATUS_GENERAL_FAILURE);
+    }
+
 
     bool TrackJobCl::doPrepareParticlesStructures(
         TrackJobCl::c_buffer_t* SIXTRL_RESTRICT pb )
@@ -1065,6 +1087,28 @@ NS(TrackJobCl_get_const_output_buffer_arg)(
     const NS(TrackJobCl) *const SIXTRL_RESTRICT job )
 {
     return ( job != nullptr ) ? job->ptrOutputBufferArg() : nullptr;
+}
+
+::NS(arch_status_t) NS(TrackJobCl_update_beam_elements_region)(
+    ::NS(TrackJobCl)* SIXTRL_RESTRICT track_job,
+    ::NS(context_size_t) const offset, NS(context_size_t) const length,
+    void const* SIXTRL_RESTRICT new_value )
+{
+    return ( track_job != nullptr )
+        ? track_job->updateBeamElementsRegion( offset, length, new_value )
+        : ::NS(ARCH_STATUS_GENERAL_FAILURE);
+}
+
+::NS(arch_status_t) NS(TrackJobCl_update_beam_elements_regions)(
+    ::NS(TrackJobCl)* SIXTRL_RESTRICT track_job,
+    ::NS(context_size_t) const num_regions_to_update,
+    ::NS(context_size_t) const* offsets, NS(context_size_t) const* lengths,
+    void const* SIXTRL_RESTRICT const* SIXTRL_RESTRICT new_value )
+{
+    return ( track_job != nullptr )
+        ? track_job->updateBeamElementsRegions(
+            num_regions_to_update, offsets, lengths, new_value )
+        : ::NS(ARCH_STATUS_GENERAL_FAILURE);
 }
 
 /* end: /opencl/internal/track_job_cl.cpp */

--- a/sixtracklib/opencl/track_job_cl.h
+++ b/sixtracklib/opencl/track_job_cl.h
@@ -54,6 +54,7 @@ namespace SIXTRL_CXX_NAMESPACE
         using output_buffer_flag_t  = _base_t::output_buffer_flag_t;
         using collect_flag_t        = _base_t::collect_flag_t;
         using push_flag_t           = _base_t::push_flag_t;
+        using status_t              = _base_t::status_t;
 
         using cl_arg_t              = SIXTRL_CXX_NAMESPACE::ClArgument;
         using cl_context_t          = SIXTRL_CXX_NAMESPACE::ClContext;
@@ -158,6 +159,16 @@ namespace SIXTRL_CXX_NAMESPACE
 
         SIXTRL_HOST_FN cl_buffer_t*
         ptrClElemByElemConfigBuffer() SIXTRL_NOEXCEPT;
+
+        SIXTRL_HOST_FN status_t updateBeamElementsRegion(
+            size_type const offset, size_type const length,
+            void const* SIXTRL_RESTRICT new_value );
+
+        SIXTRL_HOST_FN status_t updateBeamElementsRegions(
+            size_type const num_regions_to_update,
+            size_type const* SIXTRL_RESTRICT offsets,
+            size_type const* SIXTRL_RESTRICT lengths,
+            void const* SIXTRL_RESTRICT const* SIXTRL_RESTRICT new_values );
 
         protected:
 
@@ -441,6 +452,19 @@ SIXTRL_EXTERN SIXTRL_HOST_FN NS(ClArgument) const*
 NS(TrackJobCl_get_const_output_buffer_arg)(
     const NS(TrackJobCl) *const SIXTRL_RESTRICT track_job );
 
+SIXTRL_EXTERN SIXTRL_HOST_FN NS(arch_status_t)
+NS(TrackJobCl_update_beam_elements_region)(
+    NS(TrackJobCl)* SIXTRL_RESTRICT track_job,
+    NS(context_size_t) const offset, NS(context_size_t) const length,
+    void const* SIXTRL_RESTRICT new_value );
+
+SIXTRL_EXTERN SIXTRL_HOST_FN NS(arch_status_t)
+NS(TrackJobCl_update_beam_elements_regions)(
+    NS(TrackJobCl)* SIXTRL_RESTRICT track_job,
+    NS(context_size_t) const num_regions_to_update,
+    NS(context_size_t) const* offsets, NS(context_size_t) const* lengths,
+    void const* SIXTRL_RESTRICT const* SIXTRL_RESTRICT new_value );
+
 #if defined( __cplusplus ) && !defined( _GPUCODE )
 }
 #endif /* defined( __cplusplus ) && !defined( _GPUCODE ) */
@@ -541,6 +565,8 @@ namespace SIXTRL_CXX_NAMESPACE
                     this->doAssignOutputBufferToBeamMonitorsOclImp(
                         belements_buffer, this->ptrCOutputBuffer() );
                 }
+
+                this->collectBeamElements();
             }
         }
 

--- a/tests/python/opencl/test_track_job_opencl.py
+++ b/tests/python/opencl/test_track_job_opencl.py
@@ -13,7 +13,7 @@ from sixtracklib.stcommon import \
     st_BeamMonitor_assign_output_cbuffer, \
     st_Track_all_particles_element_by_element_until_turn, st_NullBuffer, \
     st_BeamMonitor_assign_output_buffer, st_Buffer_new_mapped_on_cbuffer, \
-    st_Buffer_new_from_copy, st_Particles_cbuffer_get_particles, \
+    st_Particles_cbuffer_get_particles, \
     st_Particles_buffer_get_particles
 
 from sixtracklib_test.stcommon import st_Particles_print_out, \
@@ -58,9 +58,6 @@ if __name__ == '__main__':
     assert(num_beam_elements ==
            (initial_num_beam_elements + num_beam_monitors))
 
-    lattice = st_Buffer_new_from_copy(eb)
-    assert(lattice != st_NullBuffer)
-
     # ------------------------------------------------------------------------
     initial_particles = pb.get_object(0, cls=pyst.Particles)
 
@@ -78,9 +75,6 @@ if __name__ == '__main__':
 
     ret = st_BeamMonitor_assign_output_cbuffer(
         eb, cmp_output_buffer, min_turn_id, until_turn_elem_by_elem)
-
-    ret = st_BeamMonitor_assign_output_cbuffer(
-        lattice, cmp_output_buffer, min_turn_id, until_turn_elem_by_elem)
 
     ptr_belem_buffer = st_Buffer_new_mapped_on_cbuffer(eb)
     ptr_particles = st_Particles_cbuffer_get_particles(cmp_track_pb, 0)
@@ -170,13 +164,16 @@ if __name__ == '__main__':
     cmp_pbuffer = st_Buffer_new_mapped_on_cbuffer(cmp_pb)
     assert(cmp_pbuffer != st_NullBuffer)
 
+    ret = st_BeamMonitor_assign_output_cbuffer(
+        eb, cmp_output_buffer, min_turn_id, until_turn_elem_by_elem)
+
+    lattice = st_Buffer_new_mapped_on_cbuffer(eb)
+    assert(lattice != st_NullBuffer)
+
     until_turn = 10
 
-    cmp_particles = st_Particles_buffer_get_particles(
-        cmp_pbuffer, ct.c_uint64(0))
-
-    st_Track_all_particles_until_turn(
-        cmp_particles, lattice, ct.c_int64(until_turn))
+    st_Track_all_particles_until_turn(st_Particles_buffer_get_particles(
+        cmp_pbuffer, 0), lattice, ct.c_int64(until_turn))
 
     st_Buffer_delete(lattice)
     lattice = st_NullBuffer

--- a/tests/python/opencl/test_track_job_opencl.py
+++ b/tests/python/opencl/test_track_job_opencl.py
@@ -115,9 +115,6 @@ if __name__ == '__main__':
 
     status = job.track_elem_by_elem(until_turn_elem_by_elem)
     assert(status == 0)
-
-    import pdb
-    pdb.set_trace()
     print("elem by elem tracking finished")
 
     status = job.track_until(until_turn)

--- a/tests/python/opencl/test_track_job_opencl.py
+++ b/tests/python/opencl/test_track_job_opencl.py
@@ -13,7 +13,7 @@ from sixtracklib.stcommon import \
     st_BeamMonitor_assign_output_cbuffer, \
     st_Track_all_particles_element_by_element_until_turn, st_NullBuffer, \
     st_BeamMonitor_assign_output_buffer, st_Buffer_new_mapped_on_cbuffer, \
-    st_Particles_cbuffer_get_particles, \
+    st_Buffer_new_from_copy, st_Particles_cbuffer_get_particles, \
     st_Particles_buffer_get_particles
 
 from sixtracklib_test.stcommon import st_Particles_print_out, \
@@ -58,6 +58,9 @@ if __name__ == '__main__':
     assert(num_beam_elements ==
            (initial_num_beam_elements + num_beam_monitors))
 
+    lattice = st_Buffer_new_from_copy(eb)
+    assert(lattice != st_NullBuffer)
+
     # ------------------------------------------------------------------------
     initial_particles = pb.get_object(0, cls=pyst.Particles)
 
@@ -75,6 +78,9 @@ if __name__ == '__main__':
 
     ret = st_BeamMonitor_assign_output_cbuffer(
         eb, cmp_output_buffer, min_turn_id, until_turn_elem_by_elem)
+
+    ret = st_BeamMonitor_assign_output_cbuffer(
+        lattice, cmp_output_buffer, min_turn_id, until_turn_elem_by_elem)
 
     ptr_belem_buffer = st_Buffer_new_mapped_on_cbuffer(eb)
     ptr_particles = st_Particles_cbuffer_get_particles(cmp_track_pb, 0)
@@ -116,6 +122,8 @@ if __name__ == '__main__':
     status = job.track_elem_by_elem(until_turn_elem_by_elem)
     assert(status == 0)
 
+    import pdb
+    pdb.set_trace()
     print("elem by elem tracking finished")
 
     status = job.track_until(until_turn)
@@ -162,13 +170,13 @@ if __name__ == '__main__':
     cmp_pbuffer = st_Buffer_new_mapped_on_cbuffer(cmp_pb)
     assert(cmp_pbuffer != st_NullBuffer)
 
-    lattice = st_Buffer_new_mapped_on_cbuffer(eb)
-    assert(lattice != st_NullBuffer)
-
     until_turn = 10
 
-    st_Track_all_particles_until_turn(st_Particles_buffer_get_particles(
-        cmp_pbuffer, 0), lattice, ct.c_int64(until_turn))
+    cmp_particles = st_Particles_buffer_get_particles(
+        cmp_pbuffer, ct.c_uint64(0))
+
+    st_Track_all_particles_until_turn(
+        cmp_particles, lattice, ct.c_int64(until_turn))
 
     st_Buffer_delete(lattice)
     lattice = st_NullBuffer

--- a/tests/sixtracklib/opencl/CMakeLists.txt
+++ b/tests/sixtracklib/opencl/CMakeLists.txt
@@ -33,6 +33,30 @@ if( GTEST_FOUND )
     add_test( CXX_OpenCL_ContextTests test_context_opencl_cxx )
 
     # ==========================================================================
+    # test_argument_update_region_opencl_c99:
+
+    add_executable( test_argument_update_region_opencl_c99
+                    test_argument_update_region_c99.cpp )
+
+    set( C99_UNIT_TEST_TARGETS ${C99_UNIT_TEST_TARGETS}
+         test_argument_update_region_opencl_c99 )
+
+    add_test( C99_OpenCL_ClArgumentUpdateRegionTest
+              test_argument_update_region_opencl_c99 )
+
+    # --------------------------------------------------------------------------
+    # test_argument_update_region_opencl_cxx:
+
+    add_executable( test_argument_update_region_opencl_cxx
+                    test_argument_update_region_cxx.cpp )
+
+    set( CXX_UNIT_TEST_TARGETS ${CXX_UNIT_TEST_TARGETS}
+         test_argument_update_region_opencl_cxx )
+
+    add_test( CXX_OpenCL_ClArgumentUpdateRegionTest
+              test_argument_update_region_opencl_cxx )
+
+    # ==========================================================================
     # test_buffer_opencl_c99:
 
     add_executable( test_buffer_opencl_c99 test_buffer_opencl_c99.cpp )
@@ -128,6 +152,30 @@ if( GTEST_FOUND )
 
     set_property( TEST CXX_TrackJobClCollectPushTests APPEND PROPERTY
         DEPENDS CXX_OpenCL_TrackJobClTests )
+
+    # ==========================================================================
+    # test_track_job_update_region_opencl_c99:
+
+    add_executable( test_track_job_update_region_opencl_c99
+                    test_track_job_update_region_c99.cpp )
+
+    set( C99_UNIT_TEST_TARGETS ${C99_UNIT_TEST_TARGETS}
+         test_track_job_update_region_opencl_c99 )
+
+    add_test( C99_OpenCL_ClTrackJobUpdateBeamElementsRegionTest
+              test_track_job_update_region_opencl_c99 )
+
+    # --------------------------------------------------------------------------
+    # test_track_job_update_region_opencl_cxx:
+
+    add_executable( test_track_job_update_region_opencl_cxx
+                    test_track_job_update_region_cxx.cpp )
+
+    set( CXX_UNIT_TEST_TARGETS ${CXX_UNIT_TEST_TARGETS}
+         test_track_job_update_region_opencl_cxx )
+
+    add_test( CXX_OpenCL_ClTrackJobUpdateBeamElementsRegionTest
+              test_track_job_update_region_opencl_cxx )
 
     # *************************************************************************
     # Set all properties:

--- a/tests/sixtracklib/opencl/test_argument_update_region_c99.cpp
+++ b/tests/sixtracklib/opencl/test_argument_update_region_c99.cpp
@@ -1,0 +1,174 @@
+#include "sixtracklib/opencl/argument.h"
+
+#include <algorithm>
+#include <cstdint>
+#include <cstring>
+#include <vector>
+#include <utility>
+
+#include <gtest/gtest.h>
+
+#include "sixtracklib/common/buffer.h"
+#include "sixtracklib/common/be_cavity/be_cavity.h"
+#include "sixtracklib/opencl/context.h"
+#include "sixtracklib/testlib.h"
+
+TEST( C99_OpenCL_ClArgumentUpdateRegionTest, BasicUsage )
+{
+    using buffer_t     = ::NS(Buffer);
+    using argument_t   = ::NS(ClArgument);
+    using controller_t = ::NS(ClContext);
+    using cavity_t     = ::NS(Cavity);
+    using status_t     = ::NS(arch_status_t);
+    using size_t       = ::NS(ctrl_size_t);
+
+    /* Load lattice from binary dump */
+    buffer_t* lattice = ::NS(Buffer_new_from_file)(
+        ::NS(PATH_TO_BEAMBEAM_BEAM_ELEMENTS) );
+
+    SIXTRL_ASSERT( lattice != nullptr );
+
+    /* Prepare list for cavities */
+    std::vector< size_t >   cavity_indices;
+    std::vector< size_t >   cavity_offsets;
+    std::vector< size_t >   cavity_lengths;
+    std::vector< cavity_t > cavities;
+
+    /* Find all offsets, lengths and initial cavity values */
+
+    size_t const num_beam_elements =
+        ::NS(Buffer_get_num_of_objects)( lattice );
+
+    for( size_t ii = size_t{ 0 } ; ii < num_beam_elements ; ++ii )
+    {
+        cavity_t const* ptr_cavity =
+            ::NS(BeamElements_buffer_get_const_cavity)( lattice, ii );
+
+        if( ptr_cavity != nullptr )
+        {
+            cavity_indices.push_back( ii );
+            cavity_lengths.push_back( sizeof( cavity_t ) );
+            cavity_offsets.push_back( reinterpret_cast< uintptr_t >(
+                ptr_cavity ) - ::NS(Buffer_get_data_begin_addr)( lattice ) );
+
+            cavities.push_back( *ptr_cavity );
+        }
+    }
+
+    size_t const num_cavities = cavities.size();
+    ASSERT_TRUE( num_cavities > size_t{ 0 } );
+
+    /* Initialize an OpenCL controller */
+
+    controller_t* controller = ::NS(ClContext_create)();
+    SIXTRL_ASSERT( controller != nullptr );
+
+    size_t const num_nodes =
+        ::NS(ClContextBase_get_num_available_nodes)( controller );
+
+    if( num_nodes > size_t{ 0 } )
+    {
+        ::NS(context_node_id_t) default_node_id =
+            ::NS(ClContextBase_get_default_node_id)( controller );
+
+        ::NS(ClContextBase_select_node_by_node_id)(
+            controller, &default_node_id );
+
+        argument_t* arg =
+            ::NS(ClArgument_new_from_buffer)( lattice, controller );
+
+        SIXTRL_ASSERT( arg != nullptr );
+
+        /* Change voltage on host side */
+
+        for( size_t ii = size_t{ 0 } ; ii < num_cavities ; ++ii )
+        {
+            size_t const idx = cavity_indices[ ii ];
+            cavity_t const* ptr_orig_cavity =
+                ::NS(BeamElements_buffer_get_const_cavity)( lattice, idx );
+            ASSERT_TRUE( ptr_orig_cavity != nullptr );
+
+            cavity_t* ptr_cavity = &cavities[ ii ];
+            ASSERT_TRUE( ptr_cavity != nullptr );
+            ASSERT_TRUE( 0 == ::NS(Cavity_compare_values)(
+                ptr_orig_cavity, ptr_cavity ) );
+
+            ptr_cavity->voltage *= double{ 1.05 };
+
+            if( ptr_cavity->voltage < double{ 1e-16 } )
+                    ptr_cavity->voltage += 1e3;
+
+            ASSERT_TRUE( 0 != ::NS(Cavity_compare_values)(
+                ptr_orig_cavity, ptr_cavity ) );
+
+            status_t status = NS(ClArgument_update_region)( arg,
+                cavity_offsets[ ii ], cavity_lengths[ ii ], ptr_cavity );
+
+            ASSERT_TRUE( status == ::NS(ARCH_STATUS_SUCCESS) );
+        }
+
+        /* Read back the values from the device to lattice */
+        ::NS(ClArgument_read)( arg, lattice );
+
+        /* Compare the values with the expected state */
+        for( size_t ii = size_t{ 0 } ; ii < num_cavities ; ++ii )
+        {
+            size_t const idx = cavity_indices[ ii ];
+            cavity_t const* ptr_orig_cavity =
+                NS(BeamElements_buffer_get_const_cavity)( lattice, idx );
+            ASSERT_TRUE( ptr_orig_cavity != nullptr );
+
+            cavity_t* ptr_cavity = &cavities[ ii ];
+            ASSERT_TRUE( ptr_cavity != nullptr );
+            ASSERT_TRUE( 0 == ::NS(Cavity_compare_values)(
+                ptr_orig_cavity, ptr_cavity ) );
+        }
+
+        /* Update all cavities again */
+        std::vector< void const* > ptr_cavities_begins;
+
+        for( size_t ii = size_t{ 0 } ; ii < num_cavities ; ++ii )
+        {
+            cavity_t* ptr_cavity = &cavities[ ii ];
+            ASSERT_TRUE( ptr_cavity != nullptr );
+            ptr_cavity->voltage /= double{ 1.05 };
+            ptr_cavities_begins.push_back( ptr_cavity );
+        }
+
+        status_t status = ::NS(ClArgument_update_regions)( arg, num_cavities,
+            cavity_offsets.data(), cavity_lengths.data(),
+                ptr_cavities_begins.data() );
+
+        ASSERT_TRUE( status == ::NS(ARCH_STATUS_SUCCESS) );
+
+        /* Read back the modified lattice */
+        ::NS(ClArgument_read)( arg, lattice );
+
+        /* Compare the values with the expected state */
+        for( size_t ii = size_t{ 0 } ; ii < num_cavities ; ++ii )
+        {
+            size_t const idx = cavity_indices[ ii ];
+            cavity_t const* ptr_orig_cavity =
+                ::NS(BeamElements_buffer_get_const_cavity)( lattice, idx );
+            ASSERT_TRUE( ptr_orig_cavity != nullptr );
+
+            cavity_t* ptr_cavity = &cavities[ ii ];
+            ASSERT_TRUE( ptr_cavity != nullptr );
+            ASSERT_TRUE( 0 == ::NS(Cavity_compare_values)(
+                ptr_orig_cavity, ptr_cavity ) );
+        }
+
+        ::NS(ClArgument_delete)( arg );
+        arg = nullptr;
+    }
+
+    /* Cleanup */
+
+    NS(ClContext_delete)( controller );
+    NS(Buffer_delete)( lattice );
+
+    controller = nullptr;
+    lattice = nullptr;
+}
+
+/* end: tests/sixtracklib/opencl/test_argument_update_region_cxx.cpp */

--- a/tests/sixtracklib/opencl/test_argument_update_region_cxx.cpp
+++ b/tests/sixtracklib/opencl/test_argument_update_region_cxx.cpp
@@ -1,0 +1,148 @@
+#include "sixtracklib/opencl/argument.h"
+
+#include <algorithm>
+#include <cstdint>
+#include <cstring>
+#include <vector>
+#include <utility>
+
+#include <gtest/gtest.h>
+
+#include "sixtracklib/common/buffer.hpp"
+#include "sixtracklib/common/be_cavity/be_cavity.hpp"
+#include "sixtracklib/common/be_drift/be_drift.hpp"
+#include "sixtracklib/opencl/context.h"
+#include "sixtracklib/testlib.hpp"
+
+TEST( CXX_OpenCL_ClArgumentUpdateRegionTest, BasicUsage )
+{
+    namespace st      = SIXTRL_CXX_NAMESPACE;
+    namespace st_test = SIXTRL_CXX_NAMESPACE::tests;
+
+    using buffer_t     = st::Buffer;
+    using argument_t   = st::ClArgument;
+    using controller_t = st::ClContext;
+    using cavity_t     = st::Cavity;
+    using status_t     = st::arch_status_t;
+    using size_t       = controller_t::size_type;
+
+    /* Load lattice from binary dump */
+    buffer_t lattice( ::NS(PATH_TO_BEAMBEAM_BEAM_ELEMENTS) );
+
+    /* Prepare list for cavities */
+    std::vector< size_t >   cavity_indices;
+    std::vector< size_t >   cavity_offsets;
+    std::vector< size_t >   cavity_lengths;
+    std::vector< cavity_t > cavities;
+
+    /* Find all offsets, lengths and initial cavity values */
+
+    size_t const num_beam_elements = lattice.getNumObjects();
+
+    for( size_t ii = size_t{ 0 } ; ii < num_beam_elements ; ++ii )
+    {
+        cavity_t const* ptr_cavity = lattice.get< cavity_t >( ii );
+
+        if( ptr_cavity != nullptr )
+        {
+            cavity_indices.push_back( ii );
+            cavity_lengths.push_back( sizeof( cavity_t ) );
+            cavity_offsets.push_back( reinterpret_cast< uintptr_t >(
+                ptr_cavity ) - lattice.getDataBeginAddr() );
+
+            cavities.push_back( *ptr_cavity );
+        }
+    }
+
+    size_t const num_cavities = cavities.size();
+    ASSERT_TRUE( num_cavities > size_t{ 0 } );
+
+    /* Initialize an OpenCL controller */
+
+    controller_t controller;
+    size_t const num_nodes = controller.numAvailableNodes();
+
+    if( num_nodes > size_t{ 0 } )
+    {
+        controller.selectNode( controller.defaultNodeId() );
+
+        argument_t arg( lattice, &controller );
+
+        /* Change voltage on host side */
+
+        for( size_t ii = size_t{ 0 } ; ii < num_cavities ; ++ii )
+        {
+            size_t const idx = cavity_indices[ ii ];
+            cavity_t const* ptr_orig_cavity = lattice.get< cavity_t >( idx );
+            ASSERT_TRUE( ptr_orig_cavity != nullptr );
+
+            cavity_t* ptr_cavity = &cavities[ ii ];
+            ASSERT_TRUE( ptr_cavity != nullptr );
+            ASSERT_TRUE( 0 == ::NS(Cavity_compare_values)(
+                ptr_orig_cavity->getCApiPtr(), ptr_cavity->getCApiPtr() ) );
+
+            ptr_cavity->voltage *= double{ 1.05 };
+
+            if( ptr_cavity->voltage < double{ 1e-16 } )
+                    ptr_cavity->voltage += 1e3;
+
+            ASSERT_TRUE( 0 != ::NS(Cavity_compare_values)(
+                ptr_orig_cavity->getCApiPtr(), ptr_cavity->getCApiPtr() ) );
+
+            status_t status = arg.updateRegion( cavity_offsets[ ii ],
+                sizeof( cavity_t ), ptr_cavity );
+
+            ASSERT_TRUE( status == st::ARCH_STATUS_SUCCESS );
+        }
+
+        /* Read back the values from the device to lattice */
+        arg.read( lattice );
+
+        /* Compare the values with the expected state */
+        for( size_t ii = size_t{ 0 } ; ii < num_cavities ; ++ii )
+        {
+            size_t const idx = cavity_indices[ ii ];
+            cavity_t const* ptr_orig_cavity = lattice.get< cavity_t >( idx );
+            ASSERT_TRUE( ptr_orig_cavity != nullptr );
+
+            cavity_t* ptr_cavity = &cavities[ ii ];
+            ASSERT_TRUE( ptr_cavity != nullptr );
+            ASSERT_TRUE( 0 == ::NS(Cavity_compare_values)(
+                ptr_orig_cavity->getCApiPtr(), ptr_cavity->getCApiPtr() ) );
+        }
+
+        /* Update all cavities again */
+        std::vector< void const* > ptr_cavities_begins;
+
+        for( size_t ii = size_t{ 0 } ; ii < num_cavities ; ++ii )
+        {
+            cavity_t* ptr_cavity = &cavities[ ii ];
+            ASSERT_TRUE( ptr_cavity != nullptr );
+            ptr_cavity->voltage /= double{ 1.05 };
+            ptr_cavities_begins.push_back( ptr_cavity );
+        }
+
+        status_t status = arg.updateRegions( num_cavities, cavity_offsets.data(),
+            cavity_lengths.data(), ptr_cavities_begins.data() );
+
+        ASSERT_TRUE( status == st::ARCH_STATUS_SUCCESS );
+
+        /* Read back the modified lattice */
+        arg.read( lattice );
+
+        /* Compare the values with the expected state */
+        for( size_t ii = size_t{ 0 } ; ii < num_cavities ; ++ii )
+        {
+            size_t const idx = cavity_indices[ ii ];
+            cavity_t const* ptr_orig_cavity = lattice.get< cavity_t >( idx );
+            ASSERT_TRUE( ptr_orig_cavity != nullptr );
+
+            cavity_t* ptr_cavity = &cavities[ ii ];
+            ASSERT_TRUE( ptr_cavity != nullptr );
+            ASSERT_TRUE( 0 == ::NS(Cavity_compare_values)(
+                ptr_orig_cavity->getCApiPtr(), ptr_cavity->getCApiPtr() ) );
+        }
+    }
+}
+
+/* end: tests/sixtracklib/opencl/test_argument_update_region_cxx.cpp */

--- a/tests/sixtracklib/opencl/test_track_job_cl_collect_push_c99.cpp
+++ b/tests/sixtracklib/opencl/test_track_job_cl_collect_push_c99.cpp
@@ -343,11 +343,11 @@ TEST( C99_TrackJobClCollectPushTests, TestCollectAndPush )
         ASSERT_TRUE( ::NS(BeamMonitor_get_out_address)( e09_monitor ) != be_monitor_addr_t{ 0 } );
 
         ASSERT_TRUE( ::NS(BeamMonitor_get_out_address)(
-                ::NS(BeamElements_buffer_get_beam_monitor)( copy_of_eb, 5 ) ) !=
+                ::NS(BeamElements_buffer_get_beam_monitor)( copy_of_eb, 5 ) ) ==
             ::NS(BeamMonitor_get_out_address)( e06_monitor ) );
 
         ASSERT_TRUE( ::NS(BeamMonitor_get_out_address)(
-                ::NS(BeamElements_buffer_get_beam_monitor)( copy_of_eb, 8 ) ) !=
+                ::NS(BeamElements_buffer_get_beam_monitor)( copy_of_eb, 8 ) ) ==
             ::NS(BeamMonitor_get_out_address)( e09_monitor ) );
 
         /* - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - */

--- a/tests/sixtracklib/opencl/test_track_job_cl_collect_push_cxx.cpp
+++ b/tests/sixtracklib/opencl/test_track_job_cl_collect_push_cxx.cpp
@@ -327,10 +327,10 @@ TEST( CXX_TrackJobClCollectPushTests, TestCollectAndPush )
         ASSERT_TRUE( e06_monitor->getOutAddress() != be_monitor_addr_t{ 0 } );
         ASSERT_TRUE( e09_monitor->getOutAddress() != be_monitor_addr_t{ 0 } );
 
-        ASSERT_TRUE( copy_of_eb.get< be_monitor_t >( 5 )->getOutAddress() !=
+        ASSERT_TRUE( copy_of_eb.get< be_monitor_t >( 5 )->getOutAddress() ==
                      e06_monitor->getOutAddress() );
 
-        ASSERT_TRUE( copy_of_eb.get< be_monitor_t >( 8 )->getOutAddress() !=
+        ASSERT_TRUE( copy_of_eb.get< be_monitor_t >( 8 )->getOutAddress() ==
                      e09_monitor->getOutAddress() );
 
         /* - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - */

--- a/tests/sixtracklib/opencl/test_track_job_update_region_c99.cpp
+++ b/tests/sixtracklib/opencl/test_track_job_update_region_c99.cpp
@@ -1,0 +1,158 @@
+#include "sixtracklib/opencl/track_job_cl.h"
+
+#include <algorithm>
+#include <cstdint>
+#include <cstring>
+#include <vector>
+#include <utility>
+
+#include <gtest/gtest.h>
+
+#include "sixtracklib/common/buffer.h"
+#include "sixtracklib/common/be_cavity/be_cavity.h"
+#include "sixtracklib/opencl/context.h"
+#include "sixtracklib/testlib.h"
+
+TEST( C99_OpenCL_ClArgumentUpdateRegionTest, BasicUsage )
+{
+    using buffer_t     = ::NS(Buffer);
+    using track_job_t  = ::NS(TrackJobCl);
+    using cavity_t     = ::NS(Cavity);
+    using status_t     = ::NS(arch_status_t);
+    using size_t       = ::NS(ctrl_size_t);
+
+    /* Load lattice from binary dump */
+    buffer_t* lattice = ::NS(Buffer_new_from_file)(
+        ::NS(PATH_TO_BEAMBEAM_BEAM_ELEMENTS) );
+
+    buffer_t* pb = ::NS(Buffer_new_from_file)(
+        ::NS(PATH_TO_BEAMBEAM_PARTICLES_DUMP) );
+
+    SIXTRL_ASSERT( lattice != nullptr );
+
+    /* Prepare list for cavities */
+    std::vector< size_t >   cavity_indices;
+    std::vector< size_t >   cavity_offsets;
+    std::vector< size_t >   cavity_lengths;
+    std::vector< cavity_t > cavities;
+
+    /* Find all offsets, lengths and initial cavity values */
+
+    size_t const num_beam_elements =
+        ::NS(Buffer_get_num_of_objects)( lattice );
+
+    for( size_t ii = size_t{ 0 } ; ii < num_beam_elements ; ++ii )
+    {
+        cavity_t const* ptr_cavity =
+            ::NS(BeamElements_buffer_get_const_cavity)( lattice, ii );
+
+        if( ptr_cavity != nullptr )
+        {
+            cavity_indices.push_back( ii );
+            cavity_lengths.push_back( sizeof( cavity_t ) );
+            cavity_offsets.push_back( reinterpret_cast< uintptr_t >(
+                ptr_cavity ) - ::NS(Buffer_get_data_begin_addr)( lattice ) );
+
+            cavities.push_back( *ptr_cavity );
+        }
+    }
+
+    size_t const num_cavities = cavities.size();
+    ASSERT_TRUE( num_cavities > size_t{ 0 } );
+
+    /* Initialize an OpenCL controller */
+
+    track_job_t* track_job = ::NS(TrackJobCl_new)( "0.0", pb, lattice );
+    SIXTRL_ASSERT( track_job != nullptr );
+
+    /* Change voltage on host side */
+
+    for( size_t ii = size_t{ 0 } ; ii < num_cavities ; ++ii )
+    {
+        size_t const idx = cavity_indices[ ii ];
+        cavity_t const* ptr_orig_cavity =
+            ::NS(BeamElements_buffer_get_const_cavity)( lattice, idx );
+        ASSERT_TRUE( ptr_orig_cavity != nullptr );
+
+        cavity_t* ptr_cavity = &cavities[ ii ];
+        ASSERT_TRUE( ptr_cavity != nullptr );
+        ASSERT_TRUE( 0 == ::NS(Cavity_compare_values)(
+            ptr_orig_cavity, ptr_cavity ) );
+
+        ptr_cavity->voltage *= double{ 1.05 };
+
+        if( ptr_cavity->voltage < double{ 1e-16 } )
+                ptr_cavity->voltage += 1e3;
+
+        ASSERT_TRUE( 0 != ::NS(Cavity_compare_values)(
+            ptr_orig_cavity, ptr_cavity ) );
+
+        status_t status = NS(TrackJobCl_update_beam_elements_region)( track_job,
+            cavity_offsets[ ii ], sizeof( ::NS(Cavity) ), ptr_cavity );
+
+        ASSERT_TRUE( status == ::NS(ARCH_STATUS_SUCCESS) );
+    }
+
+    /* Read back the values from the device to lattice */
+    ::NS(TrackJob_collect_beam_elements)( track_job );
+
+    /* Compare the values with the expected state */
+    for( size_t ii = size_t{ 0 } ; ii < num_cavities ; ++ii )
+    {
+        size_t const idx = cavity_indices[ ii ];
+        cavity_t const* ptr_orig_cavity =
+            NS(BeamElements_buffer_get_const_cavity)( lattice, idx );
+        ASSERT_TRUE( ptr_orig_cavity != nullptr );
+
+        cavity_t* ptr_cavity = &cavities[ ii ];
+        ASSERT_TRUE( ptr_cavity != nullptr );
+        ASSERT_TRUE( 0 == ::NS(Cavity_compare_values)(
+            ptr_orig_cavity, ptr_cavity ) );
+    }
+
+    /* Update all cavities again */
+    std::vector< void const* > ptr_cavities_begins;
+
+    for( size_t ii = size_t{ 0 } ; ii < num_cavities ; ++ii )
+    {
+        cavity_t* ptr_cavity = &cavities[ ii ];
+        ASSERT_TRUE( ptr_cavity != nullptr );
+        ptr_cavity->voltage /= double{ 1.05 };
+        ptr_cavities_begins.push_back( ptr_cavity );
+    }
+
+    status_t status = ::NS(TrackJobCl_update_beam_elements_regions)( track_job,
+        num_cavities, cavity_offsets.data(), cavity_lengths.data(),
+            ptr_cavities_begins.data() );
+
+    ASSERT_TRUE( status == ::NS(ARCH_STATUS_SUCCESS) );
+
+    /* Read back the modified lattice */
+    ::NS(TrackJob_collect_beam_elements)( track_job );
+
+    /* Compare the values with the expected state */
+    for( size_t ii = size_t{ 0 } ; ii < num_cavities ; ++ii )
+    {
+        size_t const idx = cavity_indices[ ii ];
+        cavity_t const* ptr_orig_cavity =
+            ::NS(BeamElements_buffer_get_const_cavity)( lattice, idx );
+        ASSERT_TRUE( ptr_orig_cavity != nullptr );
+
+        cavity_t* ptr_cavity = &cavities[ ii ];
+        ASSERT_TRUE( ptr_cavity != nullptr );
+        ASSERT_TRUE( 0 == ::NS(Cavity_compare_values)(
+            ptr_orig_cavity, ptr_cavity ) );
+    }
+
+    /* Cleanup */
+
+    ::NS(TrackJobCl_delete)( track_job );
+    ::NS(Buffer_delete)( lattice );
+    ::NS(Buffer_delete)( pb );
+
+    track_job = nullptr;
+    lattice = nullptr;
+    pb = nullptr;
+}
+
+/* end: tests/sixtracklib/opencl/test_track_job_update_region_c99.cpp */

--- a/tests/sixtracklib/opencl/test_track_job_update_region_cxx.cpp
+++ b/tests/sixtracklib/opencl/test_track_job_update_region_cxx.cpp
@@ -1,0 +1,138 @@
+#include "sixtracklib/opencl/track_job_cl.h"
+
+#include <algorithm>
+#include <cstdint>
+#include <cstring>
+#include <vector>
+#include <utility>
+
+#include <gtest/gtest.h>
+
+#include "sixtracklib/common/buffer.hpp"
+#include "sixtracklib/common/be_cavity/be_cavity.hpp"
+#include "sixtracklib/common/be_drift/be_drift.hpp"
+#include "sixtracklib/opencl/context.h"
+#include "sixtracklib/testlib.hpp"
+
+TEST( CXX_OpenCL_ClTrackJobUpdateBeamElementsRegionTest, BasicUsage )
+{
+    namespace st      = SIXTRL_CXX_NAMESPACE;
+    namespace st_test = SIXTRL_CXX_NAMESPACE::tests;
+
+    using buffer_t     = st::Buffer;
+    using track_job_t  = st::TrackJobCl;
+    using cavity_t     = st::Cavity;
+    using status_t     = st::arch_status_t;
+    using size_t       = track_job_t::size_type;
+
+    /* Load lattice from binary dump */
+    buffer_t lattice( ::NS(PATH_TO_BEAMBEAM_BEAM_ELEMENTS) );
+    buffer_t pb( ::NS(PATH_TO_BEAMBEAM_PARTICLES_DUMP) );
+
+    /* Prepare list for cavities */
+    std::vector< size_t >   cavity_indices;
+    std::vector< size_t >   cavity_offsets;
+    std::vector< size_t >   cavity_lengths;
+    std::vector< cavity_t > cavities;
+
+    /* Find all offsets, lengths and initial cavity values */
+
+    size_t const num_beam_elements = lattice.getNumObjects();
+
+    for( size_t ii = size_t{ 0 } ; ii < num_beam_elements ; ++ii )
+    {
+        cavity_t const* ptr_cavity = lattice.get< cavity_t >( ii );
+
+        if( ptr_cavity != nullptr )
+        {
+            cavity_indices.push_back( ii );
+            cavity_lengths.push_back( sizeof( cavity_t ) );
+            cavity_offsets.push_back( reinterpret_cast< uintptr_t >(
+                ptr_cavity ) - lattice.getDataBeginAddr() );
+
+            cavities.push_back( *ptr_cavity );
+        }
+    }
+
+    size_t const num_cavities = cavities.size();
+    ASSERT_TRUE( num_cavities > size_t{ 0 } );
+
+    /* Initialize an OpenCL controller */
+
+    track_job_t track_job( "0.0", pb, lattice );
+
+    for( size_t ii = size_t{ 0 } ; ii < num_cavities ; ++ii )
+    {
+        size_t const idx = cavity_indices[ ii ];
+        cavity_t const* ptr_orig_cavity = lattice.get< cavity_t >( idx );
+        ASSERT_TRUE( ptr_orig_cavity != nullptr );
+
+        cavity_t* ptr_cavity = &cavities[ ii ];
+        ASSERT_TRUE( ptr_cavity != nullptr );
+        ASSERT_TRUE( 0 == ::NS(Cavity_compare_values)(
+            ptr_orig_cavity->getCApiPtr(), ptr_cavity->getCApiPtr() ) );
+
+        ptr_cavity->voltage *= double{ 1.05 };
+
+        if( ptr_cavity->voltage < double{ 1e-16 } )
+                ptr_cavity->voltage += 1e3;
+
+        ASSERT_TRUE( 0 != ::NS(Cavity_compare_values)(
+            ptr_orig_cavity->getCApiPtr(), ptr_cavity->getCApiPtr() ) );
+
+        status_t status = track_job.updateBeamElementsRegion(
+            cavity_offsets[ ii ], sizeof( cavity_t ), ptr_cavity );
+
+        ASSERT_TRUE( status == st::ARCH_STATUS_SUCCESS );
+    }
+
+    /* Read back the values from the device to lattice */
+    track_job.collectBeamElements();
+
+    /* Compare the values with the expected state */
+    for( size_t ii = size_t{ 0 } ; ii < num_cavities ; ++ii )
+    {
+        size_t const idx = cavity_indices[ ii ];
+        cavity_t const* ptr_orig_cavity = lattice.get< cavity_t >( idx );
+        ASSERT_TRUE( ptr_orig_cavity != nullptr );
+
+        cavity_t* ptr_cavity = &cavities[ ii ];
+        ASSERT_TRUE( ptr_cavity != nullptr );
+        ASSERT_TRUE( 0 == ::NS(Cavity_compare_values)(
+            ptr_orig_cavity->getCApiPtr(), ptr_cavity->getCApiPtr() ) );
+    }
+
+    /* Update all cavities again */
+    std::vector< void const* > ptr_cavities_begins;
+
+    for( size_t ii = size_t{ 0 } ; ii < num_cavities ; ++ii )
+    {
+        cavity_t* ptr_cavity = &cavities[ ii ];
+        ASSERT_TRUE( ptr_cavity != nullptr );
+        ptr_cavity->voltage /= double{ 1.05 };
+        ptr_cavities_begins.push_back( ptr_cavity );
+    }
+
+    status_t status = track_job.updateBeamElementsRegions( num_cavities,
+        cavity_offsets.data(), cavity_lengths.data(), ptr_cavities_begins.data() );
+
+    ASSERT_TRUE( status == st::ARCH_STATUS_SUCCESS );
+
+    /* Read back the modified lattice */
+    track_job.collectBeamElements();
+
+    /* Compare the values with the expected state */
+    for( size_t ii = size_t{ 0 } ; ii < num_cavities ; ++ii )
+    {
+        size_t const idx = cavity_indices[ ii ];
+        cavity_t const* ptr_orig_cavity = lattice.get< cavity_t >( idx );
+        ASSERT_TRUE( ptr_orig_cavity != nullptr );
+
+        cavity_t* ptr_cavity = &cavities[ ii ];
+        ASSERT_TRUE( ptr_cavity != nullptr );
+        ASSERT_TRUE( 0 == ::NS(Cavity_compare_values)(
+            ptr_orig_cavity->getCApiPtr(), ptr_cavity->getCApiPtr() ) );
+    }
+}
+
+/* end: tests/sixtracklib/opencl/test_track_job_update_region_cxx.cpp */


### PR DESCRIPTION
- OpenCL and CPU track job automatically collect the beam-elements in case there is a beam-monitor. This ensures that pushing an updated lattice does not deactivate the beam monitors.

**Note**: This behaviour is not yet implemented for CUDA. --> TODO
- Updates unit-tests to reflect the changed default behaviour

- Introduce "updateRegion" and "updateRegions" API for arguments and track-jobs. This can be used to update only parts of the lattice without having to push the whole lattice. 

**Warning**: this is quite dangerous and can result in an inconsistent lattice. Use with care and on your own risk.