### PR TITLE
beam_elements.py: fixing `from_line` method...

### DIFF
--- a/python/sixtracklib/beam_elements.py
+++ b/python/sixtracklib/beam_elements.py
@@ -446,7 +446,9 @@ class Elements(object):
 
     @classmethod
     def from_line(cls, line):
-        return cls().append_line(line)
+        self = cls()
+        self.append_line(line)
+        return self
 
     def append_line(self, line):
         for element in line.elements:

--- a/python/sixtracklib/beam_elements.py
+++ b/python/sixtracklib/beam_elements.py
@@ -446,14 +446,13 @@ class Elements(object):
 
     @classmethod
     def from_line(cls, line):
-        self = cls()
-        self.append_line(line)
-        return self
+        return self.append_line(line)
 
     def append_line(self, line):
         for element in line.elements:
             element_name = element.__class__.__name__
             getattr(self, element_name)(**element.to_dict(keepextra=True))
+        return self
 
     def to_file(self, filename):
         self.cbuffer.tofile(filename)

--- a/python/sixtracklib/beam_elements.py
+++ b/python/sixtracklib/beam_elements.py
@@ -446,6 +446,7 @@ class Elements(object):
 
     @classmethod
     def from_line(cls, line):
+        self = cls()
         return self.append_line(line)
 
     def append_line(self, line):


### PR DESCRIPTION
...which is a class method and wrongfully did not return an instance

(the `append_line` method does not return self and probably
should not, therefore instantiate the class inside `from_line`,
append the provided line arg, and then return the instance)