### PR TITLE
cuda: fixes resource leak in CudaArgument class

### DIFF
--- a/sixtracklib/cuda/argument.hpp
+++ b/sixtracklib/cuda/argument.hpp
@@ -94,7 +94,7 @@ namespace SIXTRL_CXX_NAMESPACE
         operator=( CudaArgument const& rhs ) = delete;
         SIXTRL_HOST_FN CudaArgument& operator=( CudaArgument&& rhs ) = delete;
 
-        SIXTRL_HOST_FN virtual ~CudaArgument() = default;
+        SIXTRL_HOST_FN virtual ~CudaArgument();
 
         /* ----------------------------------------------------------------- */
 

--- a/sixtracklib/cuda/control/argument.cpp
+++ b/sixtracklib/cuda/control/argument.cpp
@@ -28,17 +28,23 @@ namespace SIXTRL_CXX_NAMESPACE
 {
     CudaArgument::CudaArgument( CudaController* SIXTRL_RESTRICT ctrl ) :
         ArgumentBase( st::ARCHITECTURE_CUDA,
-            SIXTRL_ARCHITECTURE_CUDA_STR, nullptr, true, ctrl ), 
+            SIXTRL_ARCHITECTURE_CUDA_STR, nullptr, true, ctrl ),
         m_arg_buffer( nullptr )
     {
 
+    }
+
+    CudaArgument::~CudaArgument()
+    {
+        st::CudaArgument::CudaFreeArgBuffer( this->m_arg_buffer );
+        this->m_arg_buffer = nullptr;
     }
 
     CudaArgument::CudaArgument(
         CudaArgument::buffer_t const& SIXTRL_RESTRICT_REF buffer,
         CudaController* SIXTRL_RESTRICT ctrl ) :
         ArgumentBase( st::ARCHITECTURE_CUDA,
-            SIXTRL_ARCHITECTURE_CUDA_STR, nullptr, true, ctrl ), 
+            SIXTRL_ARCHITECTURE_CUDA_STR, nullptr, true, ctrl ),
         m_arg_buffer( nullptr )
     {
         using status_t = CudaArgument::status_t;
@@ -46,7 +52,7 @@ namespace SIXTRL_CXX_NAMESPACE
 
         size_t const buffer_size = buffer.size();
         this->doReserveArgumentBufferCudaBaseImpl( buffer_size );
-                
+
         void const* buffer_data_begin = buffer.dataBegin< void const* >();
 
         if( ( buffer_size > size_t{ 0 } ) &&
@@ -64,7 +70,7 @@ namespace SIXTRL_CXX_NAMESPACE
 
             if( status == ::NS(ARCH_STATUS_SUCCESS) )
             {
-                status = ctrl->remap( 
+                status = ctrl->remap(
                     this->cudaArgBuffer(), buffer.getSlotSize() );
             }
 
@@ -80,7 +86,7 @@ namespace SIXTRL_CXX_NAMESPACE
         const CudaArgument::c_buffer_t *const SIXTRL_RESTRICT ptr_buffer,
         CudaController* SIXTRL_RESTRICT ctrl ) :
         ArgumentBase( st::ARCHITECTURE_CUDA,
-            SIXTRL_ARCHITECTURE_CUDA_STR, nullptr, true, ctrl ), 
+            SIXTRL_ARCHITECTURE_CUDA_STR, nullptr, true, ctrl ),
         m_arg_buffer( nullptr )
     {
         using status_t = CudaArgument::status_t;
@@ -102,12 +108,12 @@ namespace SIXTRL_CXX_NAMESPACE
             SIXTRL_ASSERT( this->cudaArgBuffer() != nullptr );
             SIXTRL_ASSERT( this->size() == size_t{ 0 } );
 
-            status_t status = this->cudaController()->sendMemory( 
+            status_t status = this->cudaController()->sendMemory(
                 this->cudaArgBuffer(), buffer_data_begin, buffer_size );
 
             if( status == ::NS(ARCH_STATUS_SUCCESS) )
             {
-                status = ctrl->remap( this->cudaArgBuffer(), 
+                status = ctrl->remap( this->cudaArgBuffer(),
                     ::NS(Buffer_get_slot_size( ptr_buffer ) ) );
             }
 
@@ -122,7 +128,7 @@ namespace SIXTRL_CXX_NAMESPACE
     CudaArgument::CudaArgument( CudaArgument::size_type const capacity,
         CudaController* SIXTRL_RESTRICT ctrl )  :
         ArgumentBase( st::ARCHITECTURE_CUDA,
-            SIXTRL_ARCHITECTURE_CUDA_STR, nullptr, true, ctrl ), 
+            SIXTRL_ARCHITECTURE_CUDA_STR, nullptr, true, ctrl ),
         m_arg_buffer( nullptr )
     {
         this->doReserveArgumentBufferCudaBaseImpl( capacity );
@@ -133,12 +139,12 @@ namespace SIXTRL_CXX_NAMESPACE
         CudaArgument::size_type const raw_arg_length,
         CudaController* SIXTRL_RESTRICT ctrl )  :
         ArgumentBase( st::ARCHITECTURE_CUDA,
-            SIXTRL_ARCHITECTURE_CUDA_STR, nullptr, true, ctrl ), 
+            SIXTRL_ARCHITECTURE_CUDA_STR, nullptr, true, ctrl ),
         m_arg_buffer( nullptr )
     {
         using status_t = CudaArgument::status_t;
         using size_t   = CudaArgument::size_type;
-        
+
         this->doReserveArgumentBufferCudaBaseImpl( raw_arg_length );
 
         if( ( raw_arg_length > size_t{ 0 } ) &&
@@ -162,7 +168,7 @@ namespace SIXTRL_CXX_NAMESPACE
     }
 
     /* --------------------------------------------------------------------- */
-    
+
     CudaArgument::ptr_cuda_controller_t
     CudaArgument::cudaController() SIXTRL_NOEXCEPT
     {
@@ -182,9 +188,9 @@ namespace SIXTRL_CXX_NAMESPACE
             ? this->ptrControllerBase()->asDerivedController< cuda_ctrl_t >(
                     st::ARCHITECTURE_CUDA ) : nullptr;
     }
-    
+
     /* --------------------------------------------------------------------- */
-    
+
     bool CudaArgument::hasCudaArgBuffer() const SIXTRL_NOEXCEPT
     {
         return ( ( this->hasArgumentBuffer() ) &&

--- a/sixtracklib/sixtracklib.hpp
+++ b/sixtracklib/sixtracklib.hpp
@@ -42,6 +42,7 @@
 
 #include "sixtracklib/cuda/argument.hpp"
 #include "sixtracklib/cuda/controller.hpp"
+#include "sixtracklib/cuda/track_job.hpp"
 
 #endif /* defined( SIXTRACKLIB_ENABLE_MODULE_OPENCL ) */
 


### PR DESCRIPTION
Fixes a resource leak in the CudaArgument class (memory allocated on devices did not get free'd properly unless the calling program itself was terminated -> this should work now). Sorry for the bug and thanks to @aoeftiger for his help in finding it