### PR TITLE
Bugfix/trackjob print nodes

### DIFF
--- a/python/sixtracklib/stcommon.py
+++ b/python/sixtracklib/stcommon.py
@@ -3125,9 +3125,31 @@ if SIXTRACKLIB_MODULES.get('opencl', False):
     st_OpenCL_print_all_nodes.argtypes = None
     st_OpenCL_print_all_nodes.restype = None
 
-    st_OpenCL_print_available_nodes = sixtracklib.st_OpenCL_print_available_nodes
+    st_OpenCL_print_available_nodes = \
+        sixtracklib.st_OpenCL_print_available_nodes
     st_OpenCL_print_available_nodes.argtypes = None
     st_OpenCL_print_available_nodes.restype = None
+
+    st_OpenCL_get_all_nodes_required_str_capacity = \
+        sixtracklib.st_OpenCL_get_all_nodes_required_str_capacity
+    st_OpenCL_get_all_nodes_required_str_capacity.argtypes = None
+    st_OpenCL_get_all_nodes_required_str_capacity.restype = st_arch_size_t
+
+    st_OpenCL_get_all_nodes_as_string = \
+        sixtracklib.st_OpenCL_get_all_nodes_as_string
+    st_OpenCL_get_all_nodes_as_string.argtypes = [ct.c_char_p, st_arch_size_t]
+
+    st_OpenCL_get_available_nodes_required_str_capacity = \
+        sixtracklib.st_OpenCL_get_available_nodes_required_str_capacity
+    st_OpenCL_get_available_nodes_required_str_capacity.argtypes = [
+        ct.c_char_p, ct.c_char_p]
+    st_OpenCL_get_available_nodes_required_str_capacity.restype = st_arch_size_t
+
+    st_OpenCL_get_available_nodes_as_string = \
+        sixtracklib.st_OpenCL_get_available_nodes_as_string
+    st_OpenCL_get_available_nodes_as_string.argtypes = [
+        ct.c_char_p, st_arch_size_t, ct.c_char_p, ct.c_char_p]
+    st_OpenCL_get_available_nodes_as_string.restype = st_arch_status_t
 
     st_ClContext_create = sixtracklib.st_ClContext_create
     st_ClContext_create.restype = st_Context_p

--- a/python/sixtracklib/trackjob.py
+++ b/python/sixtracklib/trackjob.py
@@ -692,14 +692,44 @@ class TrackJob(object):
         return enabled_archs
 
     @staticmethod
-    def print_nodes(arch_str, all=False):
+    def print_nodes(arch_str, all=False, filter_str=None, env_var_name=None):
         arch_str = arch_str.strip().lower()
+        if not(filter_str is None):
+            _filter_str_bytes = filter_str.strip().encode('utf-8')
+            _filter_str = ct.c_char_p(_filter_str_bytes)
+        else:
+            _filter_str = None
+
+        if not(env_var_name is None):
+            _env_var_name_bytes = env_var_name.strip().encode('utf-8')
+            _env_var_name = ct.c_char_p(_env_var_name_bytes)
+        else:
+            _env_var_name = None
+
         if stconf.SIXTRACKLIB_MODULES.get(arch_str, False):
             if arch_str == "opencl":
                 if not all:
-                    st.st_OpenCL_print_available_nodes()
+                    capacity = \
+                        st.st_OpenCL_get_available_nodes_required_str_capacity(
+                            _filter_str, _env_var_name)
                 else:
-                    st.st_OpenCL_print_all_nodes()
+                    capacity = \
+                        st.st_OpenCL_get_all_nodes_required_str_capacity()
+
+                _nodes_str = ct.create_string_buffer(capacity)
+
+                if not all:
+                    _status = st.st_OpenCL_get_available_nodes_as_string(
+                        _nodes_str, st.st_arch_size_t(capacity),
+                        _filter_str, _env_var_name)
+                else:
+                    _status = st.st_OpenCL_get_all_nodes_as_string(
+                        _nodes_str, st.st_arch_size_t(capacity))
+
+                if _status == st.st_ARCH_STATUS_SUCCESS.value and capacity > 0:
+                    print(bytes(_nodes_str).decode('utf-8'))
+                else:
+                    raise RuntimeError("unable to print opencl nodes")
             else:
                 print("nodes not available for architecture {0}".format(
                     arch_str))

--- a/sixtracklib/common/context/compute_arch.h
+++ b/sixtracklib/common/context/compute_arch.h
@@ -12,6 +12,7 @@
 
 #if !defined( SIXTRL_NO_INCLUDES )
     #include "sixtracklib/common/definitions.h"
+    #include "sixtracklib/common/control/definitions.h"
 #endif /* !defined( SIXTRL_NO_INCLUDES ) */
 
 #if !defined( _GPUCODE ) && defined( __cplusplus )
@@ -155,6 +156,12 @@ SIXTRL_EXTERN SIXTRL_HOST_FN void NS(ComputeNodeInfo_print)(
     const NS(ComputeNodeId) *const SIXTRL_RESTRICT default_node_id );
 
 SIXTRL_EXTERN SIXTRL_HOST_FN void NS(ComputeNodeInfo_print_out)(
+    const NS(ComputeNodeInfo) *const SIXTRL_RESTRICT node_info,
+    const NS(ComputeNodeId) *const SIXTRL_RESTRICT default_node_id );
+
+SIXTRL_EXTERN SIXTRL_HOST_FN NS(arch_status_t) NS(ComputeNodeInfo_print_to_str)(
+    char* SIXTRL_RESTRICT node_info_out_str,
+    NS(arch_size_t) const node_info_out_str_capacity,
     const NS(ComputeNodeInfo) *const SIXTRL_RESTRICT node_info,
     const NS(ComputeNodeId) *const SIXTRL_RESTRICT default_node_id );
 

--- a/sixtracklib/opencl/internal/base_context.cpp
+++ b/sixtracklib/opencl/internal/base_context.cpp
@@ -2715,6 +2715,34 @@ void NS(OpenCL_print_all_nodes)( void )
     st::ClContextBase::PRINT_ALL_NODES();
 }
 
+::NS(arch_size_t) NS(OpenCL_get_all_nodes_required_str_capacity)( void )
+{
+    return st::ClContextBase::GET_ALL_NODES_REQUIRED_STRING_CAPACITY();
+}
+
+::NS(arch_status_t) NS(OpenCL_get_all_nodes_as_string)(
+    char* SIXTRL_RESTRICT out_node_info_str,
+    ::NS(arch_size_t) const out_node_info_str_capacity )
+{
+    using _this_t = st::ClContextBase;
+    _this_t::status_t status = st::ARCH_STATUS_GENERAL_FAILURE;
+
+    if( ( out_node_info_str != nullptr ) &&
+        ( out_node_info_str_capacity > _this_t::size_type{ 0 } ) )
+    {
+        std::memset( out_node_info_str, ( int )'\0',
+                     out_node_info_str_capacity );
+
+        std::string const temp_str( _this_t::PRINT_ALL_NODES_TO_STRING() );
+        std::strncpy( out_node_info_str, temp_str.c_str(),
+                      out_node_info_str_capacity - _this_t::size_type{ 1 } );
+
+        status = st::ARCH_STATUS_SUCCESS;
+    }
+
+    return status;
+}
+
 /* -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- - */
 
 ::NS(arch_size_t) NS(OpenCL_num_available_nodes)(
@@ -2761,6 +2789,41 @@ void NS(OpenCL_print_available_nodes_detailed)(
     char const* SIXTRL_RESTRICT env_variable_name )
 {
     st::ClContextBase::PRINT_AVAILABLE_NODES( filter_str, env_variable_name );
+}
+
+::NS(arch_size_t) NS(OpenCL_get_available_nodes_required_str_capacity)(
+    char const* SIXTRL_RESTRICT filter_str,
+    char const* SIXTRL_RESTRICT env_variable_name )
+{
+    return st::ClContextBase::GET_AVAILABLE_NODES_REQUIRED_STRING_CAPACITY(
+        filter_str, env_variable_name );
+}
+
+::NS(arch_status_t) NS(OpenCL_get_available_nodes_as_string)(
+    char* SIXTRL_RESTRICT out_node_info_str,
+    ::NS(arch_size_t) const out_node_info_str_capacity,
+    char const* SIXTRL_RESTRICT filter_str,
+    char const* SIXTRL_RESTRICT env_variable_name )
+{
+    using _this_t = st::ClContextBase;
+    _this_t::status_t status = st::ARCH_STATUS_GENERAL_FAILURE;
+
+    if( ( out_node_info_str != nullptr ) &&
+        ( out_node_info_str_capacity > _this_t::size_type{ 0 } ) )
+    {
+        std::memset( out_node_info_str, ( int )'\0',
+                     out_node_info_str_capacity );
+
+        std::string const temp_str( _this_t::PRINT_AVAILABLE_NODES_TO_STRING(
+            filter_str, env_variable_name ) );
+
+        std::strncpy( out_node_info_str, temp_str.c_str(),
+                      out_node_info_str_capacity - _this_t::size_type{ 1 } );
+
+        status = st::ARCH_STATUS_SUCCESS;
+    }
+
+    return status;
 }
 
 /* ************************************************************************* */


### PR DESCRIPTION
the `TrackJob.print_nodes()` function now uses the python `print()` method, ensuring that the output is available also in environments such as a jupyter notebook. To this end, functions to print the node info into a C-string have been implemented in the C/C++ backend

