### PR TITLE
Bugfix/track elem by elem rolling

### DIFF
--- a/sixtracklib/common/internal/track_job_base.cpp
+++ b/sixtracklib/common/internal/track_job_base.cpp
@@ -216,71 +216,36 @@ namespace SIXTRL_CXX_NAMESPACE
         _this_t::buffer_t* SIXTRL_RESTRICT ptr_output_buffer,
         _size_t const until_turn_elem_by_elem )
     {
-        using c_buffer_t = _this_t::c_buffer_t;
-        this->doClear();
+        _size_t const particle_set_indices[] = { _size_t{ 0 }, _size_t{ 0 } };
 
-        c_buffer_t* ptr_pb  = particles_buffer.getCApiPtr();
-        c_buffer_t* ptr_eb  = be_buffer.getCApiPtr();
-        c_buffer_t* ptr_out = ( ptr_output_buffer != nullptr ) ?
-            ptr_output_buffer->getCApiPtr() : nullptr;
-
-        bool const success = this->doReset(
-            ptr_pb, ptr_eb, ptr_out, until_turn_elem_by_elem );
-
-        if( success )
-        {
-            this->doSetPtrParticleBuffer( &particles_buffer );
-            this->doSetPtrBeamElementsBuffer( &be_buffer );
-
-            if( ( ptr_out != nullptr ) && ( this->hasOutputBuffer() ) )
-            {
-                this->doSetPtrOutputBuffer( ptr_output_buffer );
-            }
-        }
-
-        return success;
-    }
-
-    bool TrackJobBase::reset(
-        _this_t::buffer_t& SIXTRL_RESTRICT_REF particles_buffer,
-        _size_t const particle_set_index,
-        _this_t::buffer_t& SIXTRL_RESTRICT_REF be_buffer,
-        _this_t::buffer_t* SIXTRL_RESTRICT ptr_output_buffer,
-        _size_t const until_turn_elem_by_elem )
-    {
-        using size_t = _size_t;
-
-        size_t particle_set_indices[] = { size_t{ 0 } };
-        particle_set_indices[ 0 ] = particle_set_index;
-
-        return TrackJobBase::reset( particles_buffer,
+        return this->reset( particles_buffer,
             &particle_set_indices[ 0 ], &particle_set_indices[ 1 ], be_buffer,
                 ptr_output_buffer, until_turn_elem_by_elem );
     }
 
     bool TrackJobBase::reset(
+        _this_t::buffer_t& SIXTRL_RESTRICT_REF particles_buffer,
+        _size_t const pset_index,
+        _this_t::buffer_t& SIXTRL_RESTRICT_REF be_buffer,
+        _this_t::buffer_t* SIXTRL_RESTRICT ptr_output_buffer,
+        _size_t const until_turn_elem_by_elem )
+    {
+        _size_t const particle_set_indices[] = { pset_index, _size_t{ 0 } };
+
+        return this->reset( particles_buffer, &particle_set_indices[ 0 ],
+            &particle_set_indices[ 1 ], be_buffer, ptr_output_buffer,
+                until_turn_elem_by_elem );
+    }
+
+    bool TrackJobBase::reset(
         _this_t::c_buffer_t* SIXTRL_RESTRICT particles_buffer,
         _this_t::c_buffer_t* SIXTRL_RESTRICT be_buffer,
         _this_t::c_buffer_t* SIXTRL_RESTRICT ptr_output_buffer,
         _size_t const until_turn_elem_by_elem )
     {
-        this->doClear();
-
-        bool const success = this->doReset( particles_buffer, be_buffer,
-                ptr_output_buffer, until_turn_elem_by_elem );
-
-        if( success )
-        {
-            this->doSetPtrCParticleBuffer( particles_buffer );
-            this->doSetPtrCBeamElementsBuffer( be_buffer );
-
-            if( ( ptr_output_buffer != nullptr ) && ( this->hasOutputBuffer() ) )
-            {
-                this->doSetPtrCOutputBuffer( ptr_output_buffer );
-            }
-        }
-
-        return success;
+        _size_t const pset_index = _size_t{ 0 };
+        return this->reset( particles_buffer, _size_t{ 1 }, &pset_index,
+            be_buffer, ptr_output_buffer, until_turn_elem_by_elem );
     }
 
     bool TrackJobBase::reset(
@@ -290,7 +255,7 @@ namespace SIXTRL_CXX_NAMESPACE
         _this_t::c_buffer_t* SIXTRL_RESTRICT ptr_output_buffer,
         _size_t const until_turn_elem_by_elem )
     {
-        return TrackJobBase::reset( particles_buffer,
+        return this->reset( particles_buffer,
             _size_t{ 1 }, &particle_set_index, be_buffer,
                 ptr_output_buffer, until_turn_elem_by_elem );
     }

--- a/sixtracklib/common/output/elem_by_elem_config.h
+++ b/sixtracklib/common/output/elem_by_elem_config.h
@@ -632,8 +632,9 @@ NS(ElemByElemConfig_get_particles_store_index_details)(
         ( NS(ElemByElemConfig_get_max_particle_id)( config ) >= particle_id ) &&
         ( NS(ElemByElemConfig_get_min_element_id)( config )  <= at_element  ) &&
         ( NS(ElemByElemConfig_get_max_element_id)( config )  >= at_element  ) &&
-        ( NS(ElemByElemConfig_get_min_turn)( config )        <= at_turn ) &&
-        ( NS(ElemByElemConfig_get_max_turn)( config )        >= at_turn ) )
+        ( NS(ElemByElemConfig_get_min_turn)( config )   <= at_turn ) &&
+        ( ( NS(ElemByElemConfig_get_max_turn)( config ) >= at_turn ) ||
+          ( NS(ElemByElemConfig_is_rolling)( config ) ) ) )
     {
         num_elem_t const particle_id_offset = ( num_elem_t )( particle_id -
             NS(ElemByElemConfig_get_min_particle_id)( config ) );


### PR DESCRIPTION
- Fixes a logical error preventing the `is_rolling` flag of `NS(ElemByElemConfig)` from properly working
- Fixes an initialization issue that may have prevented the initialization of TrackJobs with `until_turn_elem_by_elem=1` from properly working

Note: On NVIDIA OpenCL implementations, please make sure to delete the compile-cache (i.e. 
```
rm -rf ~/.nv/ComputeCache/*
```
; on my system at least, the runtime compiler was not able to pick up the changes to the included header-only parts of SixTrackLib otherwise 