### PR TITLE
SpaceCharge: fixing missing beta factor

### DIFF
--- a/sixtracklib/common/be_beamfields/track.h
+++ b/sixtracklib/common/be_beamfields/track.h
@@ -147,7 +147,7 @@ SIXTRL_INLINE NS(track_status_t) NS(Track_particle_space_charge_coasting)(
 
 
     data_ptr_t scdata = ( data_ptr_t )NS(SpaceChargeCoasting_get_const_data)( sc );
-    
+
     /*
     // Test data transfer
     printf("SCC: line_density = %e\n",scdata->line_density);
@@ -159,28 +159,28 @@ SIXTRL_INLINE NS(track_status_t) NS(Track_particle_space_charge_coasting)(
     printf("SCC: min_sigma_diff = %e\n",scdata->min_sigma_diff);
     printf("SCC: enabled = %e\n",scdata->enabled);
     */
-    
+
     SIXTRL_ASSERT( NS(Particles_get_state_value)( particles, particle_index )
         == ( NS(particle_index_t) )1 );
-    
+
     if (scdata->enabled > 0.) {
 
         real_t px = NS(Particles_get_px_value)( particles, particle_index );
         real_t py = NS(Particles_get_py_value)( particles, particle_index );
 
         real_t qratio = 1.;// To be generalized for multi-ion!
-        real_t charge = 
+        real_t charge =
 	   qratio*NS(Particles_get_q0_value)( particles, particle_index )*SIXTRL_QELEM;
 
         real_t x = NS(Particles_get_x_value)( particles, particle_index )
 	       	- scdata->x_co;
         real_t y = NS(Particles_get_y_value)( particles, particle_index )
 		- scdata->y_co;
-        
+
 	real_t chi = NS(Particles_get_chi_value)( particles, particle_index );
 
-        real_t beta = NS(Particles_get_beta0_value)( particles, particle_index ) \
-                        /NS(Particles_get_rvv_value)( particles, particle_index );
+        real_t beta0 = NS(Particles_get_beta0_value)( particles, particle_index );
+        real_t beta = beta0 / NS(Particles_get_rvv_value)( particles, particle_index );
         real_t p0c = NS(Particles_get_p0c_value)( particles, particle_index )
 		*SIXTRL_QELEM;
 
@@ -189,7 +189,7 @@ SIXTRL_INLINE NS(track_status_t) NS(Track_particle_space_charge_coasting)(
                 scdata->min_sigma_diff, 1,
                 &Ex, &Ey, &Gx, &Gy);
 
-	real_t fact_kick = chi * charge * charge * (1. - beta*beta) / p0c
+	real_t fact_kick = chi * charge * charge * (1. - beta0 * beta) / (p0c * beta)
 		* scdata->line_density * scdata->length;
         px += (fact_kick*Ex);
         py += (fact_kick*Ey);
@@ -231,14 +231,14 @@ SIXTRL_INLINE NS(track_status_t) NS(Track_particle_space_charge_bunched)(
 
     SIXTRL_ASSERT( NS(Particles_get_state_value)( particles, particle_index )
         == ( NS(particle_index_t) )1 );
-    
+
     if (scdata->enabled > 0.) {
 
         real_t px = NS(Particles_get_px_value)( particles, particle_index );
         real_t py = NS(Particles_get_py_value)( particles, particle_index );
 
         real_t qratio = 1.;// To be generalized for multi-ion!
-        real_t charge = 
+        real_t charge =
 	   qratio*NS(Particles_get_q0_value)( particles, particle_index )*SIXTRL_QELEM;
 
         real_t x = NS(Particles_get_x_value)( particles, particle_index )
@@ -246,11 +246,11 @@ SIXTRL_INLINE NS(track_status_t) NS(Track_particle_space_charge_bunched)(
         real_t y = NS(Particles_get_y_value)( particles, particle_index )
 		- scdata->y_co;
         real_t zeta = NS(Particles_get_zeta_value)( particles, particle_index );
-        
+
 	real_t chi = NS(Particles_get_chi_value)( particles, particle_index );
 
-        real_t beta = NS(Particles_get_beta0_value)( particles, particle_index ) \
-                        /NS(Particles_get_rvv_value)( particles, particle_index );
+        real_t beta0 = NS(Particles_get_beta0_value)( particles, particle_index );
+        real_t beta = beta0 / NS(Particles_get_rvv_value)( particles, particle_index );
         real_t p0c = NS(Particles_get_p0c_value)( particles, particle_index )
 		*SIXTRL_QELEM;
 
@@ -259,7 +259,7 @@ SIXTRL_INLINE NS(track_status_t) NS(Track_particle_space_charge_bunched)(
                 scdata->min_sigma_diff, 1,
                 &Ex, &Ey, &Gx, &Gy);
 
-	real_t fact_kick = chi * charge * charge * (1. - beta*beta)/p0c
+	real_t fact_kick = chi * charge * charge * (1. - beta0 * beta) / (p0c * beta)
 		* scdata->length * scdata->number_of_particles
 		/ (scdata -> bunchlength_rms * sqrt(2*SIXTRL_PI))
 		* exp(-0.5*(zeta /scdata->bunchlength_rms)


### PR DESCRIPTION
Missing beta factor inserted in `SpaceChargeBunched` and `SpaceChargeCoasting`.

Cf. [PySixTrack commit 4be6d30](https://github.com/hannes-bartosik/pysixtrack/commit/4be6d3026a1b105a487306c3387a9ff055535222)

Comparison of a bunched space charge kick between PySixTrack and SixTrackLib:
[ipynb notebook](https://github.com/aoeftiger/sixtracklib_pyht_playground/blob/3e586d9ed7305566889d4cc02e014431701e763c/sis100/2020-01-06--frozenSC-setup/Test_frozenSC.ipynb)

Space charge kick across horizontal:
![fixed spacecharge](https://user-images.githubusercontent.com/6876174/71981366-90552f00-3222-11ea-99e6-d073c8d144b6.png)

Difference between PySixTrack and SixTrackLib:

1) horizontal and vertical planes: **1e-8 difference**

![horizontal error](https://user-images.githubusercontent.com/6876174/71981416-a8c54980-3222-11ea-806a-91363ab43949.png)
![vertical error](https://user-images.githubusercontent.com/6876174/71981438-b7136580-3222-11ea-9b1c-7f5dbb5dae33.png)

2) longitudinal plane: **1e-15 difference**

![longitudinal error](https://user-images.githubusercontent.com/6876174/71981466-c4305480-3222-11ea-8eb0-6fa30dc80c49.png)
