### PR TITLE
Hotfix/issue128 fix track line

### DIFF
--- a/sixtracklib/common/be_limit/track.h
+++ b/sixtracklib/common/be_limit/track.h
@@ -72,17 +72,16 @@ SIXTRL_INLINE NS(track_status_t) NS(Track_particle_limit_global)(
 
     #endif /* SIXTRL_APERTURE_X_LIMIT && SIXTRL_APERTURE_Y_LIMIT  */
 
+    index_t state = NS(Particles_get_state_value)( p, idx );
+
     real_t const x = NS(Particles_get_x_value)( p, idx );
     real_t const y = NS(Particles_get_y_value)( p, idx );
 
     real_t const sign_x = ( real_t )( ( ZERO < x ) - ( real_t )( x < ZERO ) );
     real_t const sign_y = ( real_t )( ( ZERO < y ) - ( real_t )( y < ZERO ) );
 
-    index_t const new_state = ( index_t )(
-        ( ( sign_x * x ) < X_LIMIT ) & ( ( sign_y * y ) < Y_LIMIT ) );
-
-    SIXTRL_ASSERT( NS(Particles_is_not_lost_value)( p, idx ) );
-    NS(Particles_set_state_value)( p, idx, new_state );
+    state &= ( index_t )( ( ( sign_x * x ) < X_LIMIT ) &
+                          ( ( sign_y * y ) < Y_LIMIT ) );
 
     return SIXTRL_TRACK_SUCCESS;
 }

--- a/sixtracklib/common/be_limit/track.h
+++ b/sixtracklib/common/be_limit/track.h
@@ -83,6 +83,7 @@ SIXTRL_INLINE NS(track_status_t) NS(Track_particle_limit_global)(
     state &= ( index_t )( ( ( sign_x * x ) < X_LIMIT ) &
                           ( ( sign_y * y ) < Y_LIMIT ) );
 
+    NS(Particles_set_state_value)( p, idx, state );
     return SIXTRL_TRACK_SUCCESS;
 }
 

--- a/sixtracklib/common/be_multipole/be_multipole.h
+++ b/sixtracklib/common/be_multipole/be_multipole.h
@@ -146,7 +146,34 @@ SIXTRL_FN SIXTRL_STATIC int NS(MultiPole_compare_values_with_treshold)(
     SIXTRL_BE_ARGPTR_DEC const NS(MultiPole) *const SIXTRL_RESTRICT rhs,
     NS(multipole_real_t) const treshold );
 
+SIXTRL_FN SIXTRL_STATIC SIXTRL_BUFFER_DATAPTR_DEC NS(MultiPole) const*
+NS(BufferIndex_get_const_multipole)(
+    SIXTRL_BUFFER_OBJ_ARGPTR_DEC const NS(Object) *const index_obj );
+
+SIXTRL_FN SIXTRL_STATIC SIXTRL_BUFFER_DATAPTR_DEC NS(MultiPole)*
+NS(BufferIndex_get_multipole)( SIXTRL_BUFFER_OBJ_ARGPTR_DEC NS(Object)* index_obj );
+
+SIXTRL_FN SIXTRL_STATIC SIXTRL_BUFFER_DATAPTR_DEC NS(MultiPole) const*
+NS(BeamElements_managed_buffer_get_const_multipole)(
+    SIXTRL_BUFFER_DATAPTR_DEC unsigned char const* SIXTRL_RESTRICT pbuffer,
+    NS(buffer_size_t) const be_index, NS(buffer_size_t) const slot_size );
+
+SIXTRL_FN SIXTRL_STATIC SIXTRL_BUFFER_DATAPTR_DEC NS(MultiPole)*
+NS(BeamElements_managed_buffer_get_multipole)(
+    SIXTRL_BUFFER_DATAPTR_DEC unsigned char* SIXTRL_RESTRICT pbuffer,
+    NS(buffer_size_t) const be_index, NS(buffer_size_t) const slot_size );
+
 #if !defined( _GPUCODE )
+
+SIXTRL_STATIC SIXTRL_HOST_FN SIXTRL_BUFFER_DATAPTR_DEC NS(MultiPole) const*
+NS(BeamElements_buffer_get_const_multipole)(
+    SIXTRL_BUFFER_ARGPTR_DEC const NS(Buffer) *const SIXTRL_RESTRICT buffer,
+    NS(buffer_size_t) const be_index );
+
+SIXTRL_STATIC SIXTRL_HOST_FN SIXTRL_BUFFER_DATAPTR_DEC NS(MultiPole)*
+NS(BeamElements_buffer_get_multipole)(
+    SIXTRL_BUFFER_ARGPTR_DEC NS(Buffer)* SIXTRL_RESTRICT buffer,
+    NS(buffer_size_t) const be_index );
 
 SIXTRL_FN SIXTRL_STATIC bool NS(MultiPole_can_be_added)(
     SIXTRL_BUFFER_ARGPTR_DEC const NS(Buffer) *const SIXTRL_RESTRICT buffer,
@@ -841,7 +868,74 @@ SIXTRL_INLINE int NS(MultiPole_compare_values_with_treshold)(
     return compare_value;
 }
 
+SIXTRL_INLINE SIXTRL_BUFFER_DATAPTR_DEC NS(MultiPole) const*
+NS(BufferIndex_get_const_multipole)(
+    SIXTRL_BUFFER_OBJ_ARGPTR_DEC const NS(Object) *const index_obj )
+{
+    typedef NS(MultiPole) beam_element_t;
+    typedef SIXTRL_BUFFER_OBJ_DATAPTR_DEC beam_element_t const* ptr_to_be_t;
+    ptr_to_be_t ptr_to_be = SIXTRL_NULLPTR;
+
+    if( ( index_obj != SIXTRL_NULLPTR ) &&
+        ( NS(Object_get_type_id)( index_obj ) == NS(OBJECT_TYPE_MULTIPOLE) ) &&
+        ( NS(Object_get_size)( index_obj ) >= sizeof( beam_element_t ) ) )
+    {
+        ptr_to_be = ( ptr_to_be_t )( uintptr_t
+            )NS(Object_get_begin_addr)( index_obj );
+    }
+
+    return ptr_to_be;
+}
+
+SIXTRL_INLINE SIXTRL_BUFFER_DATAPTR_DEC NS(MultiPole)*
+NS(BufferIndex_get_multipole)(
+    SIXTRL_BUFFER_OBJ_ARGPTR_DEC NS(Object)* index_obj )
+{
+    return ( SIXTRL_BUFFER_DATAPTR_DEC NS(MultiPole)*
+        )NS(BufferIndex_get_const_multipole)( index_obj );
+}
+
+SIXTRL_INLINE SIXTRL_BUFFER_DATAPTR_DEC NS(MultiPole) const*
+NS(BeamElements_managed_buffer_get_const_multipole)(
+    SIXTRL_BUFFER_DATAPTR_DEC unsigned char const* SIXTRL_RESTRICT pbuffer,
+    NS(buffer_size_t) const be_index, NS(buffer_size_t) const slot_size )
+{
+    return NS(BufferIndex_get_const_multipole)(
+        NS(ManagedBuffer_get_const_object)( pbuffer, be_index, slot_size ) );
+}
+
+SIXTRL_INLINE SIXTRL_BUFFER_DATAPTR_DEC NS(MultiPole)*
+NS(BeamElements_managed_buffer_get_multipole)(
+    SIXTRL_BUFFER_DATAPTR_DEC unsigned char* SIXTRL_RESTRICT pbuffer,
+    NS(buffer_size_t) const be_index, NS(buffer_size_t) const slot_size )
+{
+    return NS(BufferIndex_get_multipole)(
+        NS(ManagedBuffer_get_object)( pbuffer, be_index, slot_size ) );
+}
+
 #if !defined( _GPUCODE )
+
+SIXTRL_INLINE SIXTRL_BUFFER_DATAPTR_DEC NS(MultiPole) const*
+NS(BeamElements_buffer_get_const_multipole)(
+    SIXTRL_BUFFER_ARGPTR_DEC const NS(Buffer) *const SIXTRL_RESTRICT buffer,
+    NS(buffer_size_t) const be_index )
+{
+    typedef SIXTRL_BUFFER_DATAPTR_DEC unsigned char const* ptr_raw_t;
+    return NS(BeamElements_managed_buffer_get_const_multipole)(
+        ( ptr_raw_t )( uintptr_t )NS(Buffer_get_data_begin_addr)( buffer ),
+        be_index, NS(Buffer_get_slot_size)( buffer ) );
+}
+
+SIXTRL_INLINE SIXTRL_BUFFER_DATAPTR_DEC NS(MultiPole)*
+NS(BeamElements_buffer_get_multipole)(
+    SIXTRL_BUFFER_ARGPTR_DEC NS(Buffer)* SIXTRL_RESTRICT buffer,
+    NS(buffer_size_t) const be_index )
+{
+    typedef SIXTRL_BUFFER_DATAPTR_DEC unsigned char* ptr_raw_t;
+    return NS(BeamElements_managed_buffer_get_multipole)(
+        ( ptr_raw_t )( uintptr_t )NS(Buffer_get_data_begin_addr)( buffer ),
+        be_index, NS(Buffer_get_slot_size)( buffer ) );
+}
 
 SIXTRL_INLINE bool NS(MultiPole_can_be_added)(
     SIXTRL_BE_ARGPTR_DEC const NS(Buffer) *const SIXTRL_RESTRICT buffer,

--- a/sixtracklib/common/be_multipole/be_multipole.hpp
+++ b/sixtracklib/common/be_multipole/be_multipole.hpp
@@ -364,6 +364,22 @@ namespace SIXTRL_CXX_NAMESPACE
         ::NS(multipole_real_t) const length = ::NS(multipole_real_t){ 0.0 },
         ::NS(multipole_real_t) const hxl    = ::NS(multipole_real_t){ 0.0 },
         ::NS(multipole_real_t) const hyl    = ::NS(multipole_real_t){ 0.0 } );
+
+    template<> struct ObjectTypeTraits< ::NS(MultiPole) >
+    {
+        SIXTRL_STATIC SIXTRL_INLINE object_type_id_t Type() SIXTRL_NOEXCEPT
+        {
+            return NS(OBJECT_TYPE_MULTIPOLE);
+        }
+    };
+
+    template<> struct ObjectTypeTraits< MultiPole >
+    {
+        SIXTRL_STATIC SIXTRL_INLINE object_type_id_t Type() SIXTRL_NOEXCEPT
+        {
+            return NS(OBJECT_TYPE_MULTIPOLE);
+        }
+    };
 }
 
 /* ************************************************************************* *

--- a/sixtracklib/common/track/track.h
+++ b/sixtracklib/common/track/track.h
@@ -624,7 +624,8 @@ SIXTRL_INLINE NS(track_status_t) NS(Track_particle_line_objs)(
     bool const finish_turn )
 {
     NS(track_status_t) success = SIXTRL_TRACK_SUCCESS;
-    bool continue_tracking = ( line_it != line_end );
+    bool continue_tracking = ( ( line_it != line_end ) &&
+        ( NS(Particles_is_not_lost_value)( particles, index ) ) );
 
     SIXTRL_ASSERT( line_it != SIXTRL_NULLPTR );
     SIXTRL_ASSERT( particles != SIXTRL_NULLPTR );


### PR DESCRIPTION
Attempts to fix the problems encountered in isseu #128 by changing the behavior of the global aperture check and the `track_line` method:

- by using 
```state &= ((|x|<LIMIT_X)&&(|y|<LIMIT_Y))```
instead of "updating" the state only with the right-hand-side of the expression above, we no longer rely on external logic to ensure that already lost particles are not updated again. I.e. by virtue of the bit-wise `&`, particles can only be marked as lost by this method

- Adding additional checks at the entry of the `NS(Track_particle_line_objs)` to repel already lost particles, the behaviour of the outer loop in `track_until`is reproduced even though this outer loop is missing in the context of `track_line`. This should ensure that invoking `track_line` always skips already lost particles, regardless of the history of the particles and how they have been lost.

Feedback & tests would be appreciated