### PR TITLE
Integration branch SixTrackLib v0.6.1

### DIFF
--- a/sixtracklib/common/internal/track_job_base.cpp
+++ b/sixtracklib/common/internal/track_job_base.cpp
@@ -50,7 +50,7 @@ namespace SIXTRL_CXX_NAMESPACE
     {
         namespace st            = SIXTRL_CXX_NAMESPACE;
         using tjob_t            = st::TrackJobBase;
-        using st_size_t         = st_size_t;
+        using st_size_t         = tjob_t::size_type;
         using st_status_t       = tjob_t::status_t;
         using st_track_status_t = tjob_t::track_status_t;
         using paddr_t           = tjob_t::particles_addr_t;


### PR DESCRIPTION
- Renamed #134 to take all changes that should go into the v0.6.1 version

Includes:
- Fix to #133: Due to a search & replace error, 'sixtrack::(anonymous)::st_size_t` is defined as an alias to `::st_size_t` which is not necessarily the same size as `unsigned long long`.